### PR TITLE
daemon/control: add 'control retrieve_logs' command

### DIFF
--- a/common/logf.proto
+++ b/common/logf.proto
@@ -25,18 +25,9 @@ syntax = "proto2";
 
 option java_package = "de.fraunhofer.aisec.trustme";
 
-enum LogPriority {
-	TRACE = 1;
-	DEBUG = 2;
-	INFO = 3;
-	WARN = 4;
-	ERROR = 5;
-	FATAL = 6;
-	SILENT = 7;
-}
 
 message LogMessage {
-	required LogPriority prio = 1;
+	required string name = 1;
 	required string msg = 2;
 }
 

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -73,8 +73,7 @@ message ControllerToDaemon {
 		// Also fills [container_uuids] with the corresponding container UUIDs.
 		GET_CONTAINER_CONFIG = 4;	// [container_uuid] -> [container_config]
 
-		//Returns /proc/last_kmsg and /dev/log/main (line by line).
-		//This is a debugging feature!
+		//Returns logfiles stored in LOGFILE_DIR
 		GET_LAST_LOG = 5;
 
 		//////////////////////////////////////////////


### PR DESCRIPTION
This new command copies all log files from /data/logs to /tmp/00000000-0000-0000-0000-000000000000/var/logs to make them accessible in c0.

Signed-off-by: Corinna Lingstädt <corinna.lingstaedt@aisec.fraunhofer.de>