### PR TITLE
Backports: c_fifo cleanup, overlay/tmpfs permissions, c_run

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -101,6 +101,14 @@ file_is_socket(const char *file)
 	return !lstat(file, &s) && S_ISSOCK(s.st_mode);
 }
 
+bool
+file_is_fifo(const char *file)
+{
+	struct stat s;
+
+	return !lstat(file, &s) && S_ISFIFO(s.st_mode);
+}
+
 int
 file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, off_t seek)
 {

--- a/common/file.h
+++ b/common/file.h
@@ -54,6 +54,9 @@ file_is_mountpoint(const char *file);
 bool
 file_is_socket(const char *file);
 
+bool
+file_is_fifo(const char *file);
+
 /**
  * Copy a file.
  * @param in_file The file to be read.

--- a/daemon/c_fifo.c
+++ b/daemon/c_fifo.c
@@ -34,18 +34,23 @@
 #include "common/uuid.h"
 #include "common/str.h"
 #include "common/fd.h"
+#include "common/event.h"
+#include "common/file.h"
 
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <fcntl.h>
 #include <sched.h>
+#include <signal.h>
 
 #define FIFO_PATH "/dev/fifos"
 
 struct c_fifo {
 	container_t *container;
 	list_t *fifo_list;
+	list_t *forwarder_list;
 };
 
 c_fifo_t *
@@ -61,26 +66,103 @@ c_fifo_new(container_t *container, list_t *fifo_list)
 	return fifo;
 }
 
+void
+c_fifo_free(c_fifo_t *fifo)
+{
+	ASSERT(fifo);
+	mem_free0(fifo);
+}
+
+static char *
+c_fifo_get_c0_path_new(c_fifo_t *fifo)
+{
+	pid_t c0_pid, target_pid;
+	container_t *c0 = cmld_containers_get_c0();
+	char *fifo_path_c0;
+
+	if (c0 &&
+	    (c0_pid = container_get_pid(c0)) != (target_pid = container_get_pid(fifo->container))) {
+		fifo_path_c0 =
+			mem_printf("/tmp/%s/%s", uuid_string(container_get_uuid(c0)), FIFO_PATH);
+
+		TRACE("Creating c0 fifos at %s, ns_pid=%d", fifo_path_c0, c0_pid);
+	} else if (cmld_is_hostedmode_active()) {
+		fifo_path_c0 = mem_printf("/tmp/cmlfifos/");
+
+		TRACE("Creating c0 FIFOs on host at %s", fifo_path_c0);
+	} else {
+		DEBUG("Could not get c0 instance, not preparing FIFOs for container %s",
+		      container_get_name(fifo->container));
+		return NULL;
+	}
+
+	return fifo_path_c0;
+}
+
+static char *
+c_fifo_get_container_path_new(c_fifo_t *fifo)
+{
+	return mem_printf("/tmp/%s/%s/", uuid_string(container_get_uuid(fifo->container)),
+			  FIFO_PATH);
+}
+
+void
+c_fifo_cleanup(void *fifop)
+{
+	c_fifo_t *fifo = (c_fifo_t *)fifop;
+	ASSERT(fifo);
+
+	char *fifo_path_c0 = c_fifo_get_c0_path_new(fifo);
+	IF_NULL_RETURN_DEBUG(fifo_path_c0);
+
+	while (fifo->forwarder_list) {
+		pid_t *pid = fifo->forwarder_list->data;
+		ASSERT(pid);
+		ASSERT(0 < *pid);
+
+		DEBUG("Stopping forwarder %d", *pid);
+		kill(*pid, SIGKILL);
+		waitpid(*pid, NULL, 0);
+
+		mem_free(pid);
+		fifo->forwarder_list = list_unlink(fifo->forwarder_list, fifo->forwarder_list);
+	}
+
+	// clean up FIFOs in c0
+	// FIFOs in container are removed during c_vol cleanup
+	for (list_t *elem = fifo->fifo_list; elem != NULL; elem = elem->next) {
+		char *current_fifo = (char *)elem->data;
+		if (!current_fifo)
+			continue;
+
+		char *current_path = mem_printf("%s/%s", fifo_path_c0, current_fifo);
+
+		DEBUG("Removing FIFO at %s", current_path);
+		if (0 != unlink(current_path)) {
+			ERROR("Failed to remove FIFO at %s", current_path);
+		}
+		mem_free(current_path);
+	}
+}
+
 static int
-c_fifo_create_fifos(c_fifo_t *fifo, container_t *container)
+c_fifo_create_fifos(c_fifo_t *fifo, uid_t uid, const char *fifo_dir, const uuid_t *container_uuid)
 {
 	IF_NULL_RETVAL_ERROR(fifo, -1);
-	IF_NULL_RETVAL_ERROR(container, -1);
+	IF_NULL_RETVAL_ERROR(fifo_dir, -1);
+	const char *audit_subject;
 
-	char *fifo_dir;
+	if (cmld_is_hostedmode_active()) {
+		audit_subject = "";
+	} else {
+		IF_NULL_RETVAL_ERROR(container_uuid, -1);
+		audit_subject = uuid_string(container_uuid);
+	}
 
-	const char *uuid = uuid_string(container_get_uuid(container));
-	IF_NULL_RETVAL_ERROR(uuid, -1);
-
-	uid_t uid = container_get_uid(container);
-
-	DEBUG("Creating FIFO ends for container %s with uid %d", uuid, uid);
-
-	fifo_dir = mem_printf("/tmp/%s%s", uuid, FIFO_PATH);
+	DEBUG("Creating FIFO ends at path %s", fifo_dir);
 
 	if (dir_mkdir_p(fifo_dir, 0755) < 0 && errno != EEXIST) {
-		ERROR_ERRNO("Could not mkdir %s dir for container %s", fifo_dir,
-			    container_get_name(fifo->container));
+		ERROR_ERRNO("Could not create fifo_dir at %s", fifo_dir);
 		goto error;
 	}
 
@@ -91,7 +173,7 @@ c_fifo_create_fifos(c_fifo_t *fifo, container_t *container)
 		goto error;
 	}
 
-	TRACE("Chowned FIFO at %s to %d", fifo_dir, uid);
+	TRACE("Chowned FIFO dir at %s to %d", fifo_dir, uid);
 
 	for (list_t *elem = fifo->fifo_list; elem != NULL; elem = elem->next) {
 		char *current_fifo = elem->data;
@@ -99,45 +181,37 @@ c_fifo_create_fifos(c_fifo_t *fifo, container_t *container)
 
 		char *fifo_path = mem_printf("%s/%s", fifo_dir, current_fifo);
 		if (0 != mkfifo(fifo_path, 666)) {
+			audit_log_event(container_uuid, FSA, CMLD, CONTAINER_ISOLATION,
+					"create-fifo", audit_subject, 2, "name", current_fifo, 0);
 			ERROR_ERRNO("Failed to create fifo at %s", fifo_path);
+
 			mem_free0(fifo_path);
-			audit_log_event(container_get_uuid(fifo->container), FSA, CMLD,
-					CONTAINER_ISOLATION, "create-fifo",
-					uuid_string(container_get_uuid(fifo->container)), 2, "name",
-					current_fifo, 0);
 			goto error;
 		}
 
-		audit_log_event(container_get_uuid(fifo->container), SSA, CMLD, CONTAINER_ISOLATION,
-				"create-fifo", uuid_string(container_get_uuid(fifo->container)), 2,
-				"name", current_fifo);
-		TRACE("Created FIFO at %s", fifo_path);
+		audit_log_event(container_uuid, SSA, CMLD, CONTAINER_ISOLATION, "create-fifo",
+				audit_subject, 2, "name", current_fifo);
 
 		if (chown(fifo_path, uid, uid)) {
-			audit_log_event(container_get_uuid(fifo->container), FSA, CMLD,
-					CONTAINER_ISOLATION, "prepare-fifo-directory",
-					uuid_string(container_get_uuid(fifo->container)), 2, "path",
+			audit_log_event(container_uuid, FSA, CMLD, CONTAINER_ISOLATION,
+					"prepare-fifo-directory", audit_subject, 2, "path",
 					fifo_path);
 			ERROR("Failed to chown fifo dir to %d", uid);
+
 			mem_free0(fifo_path);
 			goto error;
 		}
 
-		audit_log_event(container_get_uuid(fifo->container), SSA, CMLD, CONTAINER_ISOLATION,
-				"prepare-fifo-directory",
-				uuid_string(container_get_uuid(fifo->container)), 2, "path",
-				fifo_path);
+		audit_log_event(container_uuid, SSA, CMLD, CONTAINER_ISOLATION,
+				"prepare-fifo-directory", audit_subject, 2, "path", fifo_path);
 		DEBUG("Chowned FIFO at %s to %d", fifo_path ? fifo_path : "NULL", uid);
 
 		mem_free0(fifo_path);
 	}
 
-	mem_free0(fifo_dir);
-
 	return 0;
 
 error:
-	mem_free0(fifo_dir);
 	return -1;
 }
 
@@ -156,11 +230,21 @@ c_fifo_loop(char *fifo_path_c0, char *fifo_path_container)
 			TRACE_ERRNO("Failed to close old reading fd");
 		}
 
+		if (!file_is_fifo(fifo_path_c0)) {
+			ERROR("Could not open FIFO at %s, stopping forwarder", fifo_path_c0);
+			exit(0);
+		}
+
 		if (-1 == (fromfd = open(fifo_path_c0, O_RDONLY))) {
 			ERROR_ERRNO("Failed to open fromfd at %s, exiting...", fifo_path_c0);
 			exit(-1);
 		}
 		TRACE("Opened reading end for %s", fifo_path_c0);
+
+		if (!file_is_fifo(fifo_path_container)) {
+			ERROR("Could not open FIFO at %s, stopping forwarder", fifo_path_container);
+			exit(0);
+		}
 
 		if (-1 == (tofd = open(fifo_path_container, O_WRONLY))) {
 			ERROR_ERRNO("Failed to open tofd at %s, exiting ...", fifo_path_container);
@@ -173,82 +257,121 @@ c_fifo_loop(char *fifo_path_c0, char *fifo_path_container)
 		int count = 0;
 		char buf[1024];
 
-		while (1) {
-			if (0 < (count = read(fromfd, &buf, sizeof(buf) - 1))) {
-				TRACE("[READLOOP] Read returned %d, writing to target FIFO", count);
+		if (0 < (count = read(fromfd, &buf, sizeof(buf) - 1))) {
+			TRACE("[READLOOP] Read returned %d, writing to target FIFO", count);
 
-				buf[count] = 0;
-				TRACE("[READLOOP] Read %d bytes from fd: %d: %s", count, fromfd,
-				      buf);
+			buf[count] = 0;
+			TRACE("[READLOOP] Read %d bytes from fd: %d: %s", count, fromfd, buf);
 
-				if (count != fd_write(tofd, buf, count)) {
-					ERROR("Could not write all bytes to container FIFO end.");
-					break;
-				}
-			} else {
-				TRACE("[READLOOP] Read returned %d, try to reopen fds", count);
+			if (count != fd_write(tofd, buf, count)) {
+				ERROR("Could not write all bytes to container FIFO end.");
+				break;
 			}
+		} else {
+			TRACE("[READLOOP] Read returned %d, try to reopen fds", count);
 		}
 	}
+
+	exit(0);
 }
 
 int
 c_fifo_start_post_clone(c_fifo_t *fifo)
 {
-	int c0_pid = -1, target_pid = -1;
+	ASSERT(fifo);
+
 	container_t *c0 = cmld_containers_get_c0();
+	int ret = -1;
+	char *fifo_path_c0 = NULL, *fifo_path_container = NULL;
+	uid_t c0uid;
 
-	if (c0 &&
-	    (c0_pid = container_get_pid(c0)) != (target_pid = container_get_pid(fifo->container))) {
-		DEBUG("Creating FIFOs in c0, ns_pid=%d", c0_pid);
-
-		if (-1 == c_fifo_create_fifos(fifo, c0)) {
-			ERROR("Failed to prepare container FIFOs in c0");
-			return -1;
-		}
-
-		DEBUG("Creating FIFOs in target container, ns_pid=%d", target_pid);
-
-		if (-1 == c_fifo_create_fifos(fifo, fifo->container)) {
-			ERROR("Failed to prepare container FIFOs in target container");
-			return -1;
-		}
-
-		//fork FIFO forwarding child
-		for (list_t *elem = fifo->fifo_list; elem != NULL; elem = elem->next) {
-			char *current_fifo = elem->data;
-
-			int pid = fork();
-
-			if (-1 == pid) {
-				ERROR("Failed to clone forwarding child");
-				return -1;
-			} else if (pid == 0) {
-				DEBUG("Preparing forwarding for FIFO \'%s\'", current_fifo);
-
-				char *fifo_path_c0 = mem_printf("/tmp/%s/%s/%s",
-								uuid_string(container_get_uuid(c0)),
-								FIFO_PATH, current_fifo);
-				char *fifo_path_container =
-					mem_printf("/tmp/%s/%s/%s",
-						   uuid_string(container_get_uuid(fifo->container)),
-						   FIFO_PATH, current_fifo);
-
-				DEBUG("Forwarding from %s to %s", fifo_path_c0,
-				      fifo_path_container);
-
-				c_fifo_loop(fifo_path_c0, fifo_path_container);
-
-				exit(EXIT_FAILURE);
-			}
-
-			DEBUG("Forked FIFO forwarding child %d for %s", pid, current_fifo);
-		}
-
-	} else {
-		DEBUG("Could not get c0 instance, not preparing FIFOs for container %s",
-		      container_get_name(fifo->container));
+	if (cmld_containers_get_c0() == fifo->container) {
+		DEBUG("Skipping fifo creation for c0");
+		return 0;
 	}
 
-	return 0;
+	// create FIFOs in c0
+	DEBUG("Creating FIFOs in c0");
+	fifo_path_c0 = c_fifo_get_c0_path_new(fifo);
+	IF_NULL_RETVAL_ERROR(fifo_path_c0, -1);
+
+	if (cmld_is_hostedmode_active()) {
+		c0uid = 0;
+		if (-1 == c_fifo_create_fifos(fifo, c0uid, fifo_path_c0, NULL)) {
+			ERROR("Failed to prepare container FIFOs on host");
+			ret = -1;
+			goto error;
+		}
+	} else {
+		c0uid = container_get_uid(c0);
+		if (-1 == c_fifo_create_fifos(fifo, c0uid, fifo_path_c0,
+					      container_get_uuid(cmld_containers_get_c0()))) {
+			ERROR("Failed to prepare container FIFOs in c0");
+			ret = -1;
+			goto error;
+		}
+	}
+
+	// create FIFOs in container
+	DEBUG("Creating FIFOs in target container");
+	fifo_path_container = c_fifo_get_container_path_new(fifo);
+
+	if (-1 == c_fifo_create_fifos(fifo, container_get_uid(fifo->container), fifo_path_container,
+				      container_get_uuid(fifo->container))) {
+		ERROR("Failed to prepare container FIFOs in target container");
+		ret = -1;
+
+		goto error;
+	}
+
+	//fork FIFO forwarding childs
+	for (list_t *elem = fifo->fifo_list; elem != NULL; elem = elem->next) {
+		char *current_fifo = elem->data;
+		char *current_fifo_c0 = mem_printf("%s/%s", fifo_path_c0, current_fifo);
+		char *current_fifo_container =
+			mem_printf("%s/%s", fifo_path_container, current_fifo);
+
+		int pid = fork();
+
+		if (-1 == pid) {
+			ERROR("Failed to clone forwarding child");
+			mem_free(current_fifo_c0);
+			mem_free(current_fifo_container);
+
+			ret = -1;
+
+			goto error;
+
+		} else if (pid == 0) {
+			DEBUG("Preparing forwarding for FIFO \'%s\'", current_fifo);
+
+			DEBUG("Forwarding from %s to %s", current_fifo_c0, current_fifo_container);
+
+			event_reset();
+
+			c_fifo_loop(current_fifo_c0, current_fifo_container);
+
+			exit(EXIT_FAILURE);
+		}
+
+		mem_free(current_fifo_c0);
+		mem_free(current_fifo_container);
+
+		pid_t *mpid = mem_alloc(sizeof(pid_t));
+		*mpid = pid;
+		DEBUG("Appending %d to forwarder list", *mpid);
+		fifo->forwarder_list = list_append(fifo->forwarder_list, mpid);
+
+		DEBUG("Forked FIFO forwarding child %d for %s", pid, current_fifo);
+	}
+
+	ret = 0;
+
+error:
+	mem_free(fifo_path_c0);
+
+	if (fifo_path_container)
+		mem_free(fifo_path_container);
+
+	return ret;
 }

--- a/daemon/c_fifo.h
+++ b/daemon/c_fifo.h
@@ -28,6 +28,12 @@
 
 typedef struct c_fifo c_fifo_t;
 
+void
+c_fifo_cleanup(void *fifo);
+
+void
+c_fifo_free(c_fifo_t *fifo);
+
 int
 c_fifo_start_child(c_fifo_t *fifo);
 

--- a/daemon/c_run.c
+++ b/daemon/c_run.c
@@ -114,6 +114,10 @@ c_run_session_new(c_run_t *run, int create_pty, char *cmd, ssize_t argc, char **
 	fd_make_non_blocking(session->console_sock_cmld);
 	fd_make_non_blocking(session->console_sock_container);
 
+	session->cmd = mem_strdup(cmd);
+	session->argc = argc;
+	session->create_pty = create_pty;
+
 	ssize_t i = 0;
 	size_t total_len = ADD_WITH_OVERFLOW_CHECK(session->argc, (size_t)1);
 	total_len = MUL_WITH_OVERFLOW_CHECK(sizeof(char *), total_len);
@@ -125,10 +129,6 @@ c_run_session_new(c_run_t *run, int create_pty, char *cmd, ssize_t argc, char **
 		i++;
 	}
 	session->argv[i] = NULL;
-
-	session->cmd = mem_strdup(cmd);
-	session->argc = argc;
-	session->create_pty = create_pty;
 
 	return session;
 }

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -513,6 +513,13 @@ c_vol_mount_overlay(const char *target_dir, const char *upper_fstype, const char
 		goto error;
 	}
 	mem_free0(overlayfs_options);
+
+	if (chmod(target_dir, 0755) < 0) {
+		ERROR_ERRNO("Could not set permissions of overlayfs mount point at %s", target_dir);
+		goto error;
+	}
+	DEBUG("Changed permissions of %s to 0755", target_dir);
+
 	if (chdir(cwd))
 		WARN("Could not change back to former cwd %s", cwd);
 	mem_free0(cwd);
@@ -731,6 +738,15 @@ c_vol_mount_image(c_vol_t *vol, const char *root, const mount_entry_t *mntent)
 			  tmpfs_opts) >= 0) {
 			DEBUG("Sucessfully mounted %s to %s", mount_entry_get_fs(mntent), dir);
 			mem_free0(tmpfs_opts);
+
+			if (chmod(dir, 0755) < 0) {
+				ERROR_ERRNO(
+					"Could not set permissions of overlayfs mount point at %s",
+					dir);
+				goto error;
+			}
+			DEBUG("Changed permissions of %s to 0755", dir);
+
 			if (is_root && setup_mode && c_vol_setup_busybox_copy(dir) < 0)
 				WARN("Cannot copy busybox for setup mode!");
 			goto final;
@@ -865,6 +881,7 @@ c_vol_mount_image(c_vol_t *vol, const char *root, const mount_entry_t *mntent)
 		}
 		DEBUG("Successfully mounted %s using overlay to %s", img, dir);
 		mem_free0(overlayfs_mount_dir);
+
 		goto final;
 	}
 
@@ -1188,6 +1205,12 @@ c_vol_mount_dev(c_vol_t *vol)
 	} else {
 		DEBUG("Applied MS_SHARED to %s", dev_mnt);
 	}
+
+	if (chmod(dev_mnt, 0755) < 0) {
+		ERROR_ERRNO("Could not set permissions of overlayfs mount point at %s", dev_mnt);
+		goto error;
+	}
+	DEBUG("Changed permissions of %s to 0755", dev_mnt);
 
 	ret = 0;
 error:
@@ -1713,6 +1736,18 @@ c_vol_start_child(c_vol_t *vol)
 		goto error;
 	}
 
+	if (chmod("/run", 0755) < 0) {
+		ERROR_ERRNO("Could not set permissions of overlayfs mount point at %s", "/run");
+		goto error;
+	}
+	DEBUG("Changed permissions of %s to 0755", "/run");
+
+	if (chmod("/run", 0755) < 0) {
+		ERROR_ERRNO("Could not set permissions of overlayfs mount point at %s", "/run");
+		goto error;
+	}
+	DEBUG("Changed permissions of %s to 0755", "/run");
+
 	DEBUG("Mounting " CMLD_SOCKET_DIR);
 	if (mkdir(CMLD_SOCKET_DIR, 0755) < 0 && errno != EEXIST) {
 		ERROR_ERRNO("Could not mkdir " CMLD_SOCKET_DIR);
@@ -1722,6 +1757,13 @@ c_vol_start_child(c_vol_t *vol)
 		ERROR_ERRNO("Could not mount " CMLD_SOCKET_DIR);
 		goto error;
 	}
+
+	if (chmod(CMLD_SOCKET_DIR, 0755) < 0) {
+		ERROR_ERRNO("Could not set permissions of overlayfs mount point at %s",
+			    CMLD_SOCKET_DIR);
+		goto error;
+	}
+	DEBUG("Changed permissions of %s to 0755", CMLD_SOCKET_DIR);
 
 	if (container_has_setup_mode(vol->container) && c_vol_setup_busybox_install() < 0)
 		WARN("Cannot install busybox symlinks for setup mode!");

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -991,6 +991,7 @@ container_audit_get_loginuid(const container_t *container)
 static void
 container_cleanup(container_t *container, bool is_rebooting)
 {
+	c_fifo_cleanup(container->fifo);
 	c_cgroups_cleanup(container->cgroups);
 	c_service_cleanup(container->service);
 	c_run_cleanup(container->run);


### PR DESCRIPTION
This commit ports fixes for the c_fifo and c_run subsystems as well as a patch for the permissions of overlay/tmpfs mount points