### PR TITLE
Idmapped cidmapped

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -118,6 +118,7 @@ SRC_FILES := main.c \
 SRC_CMODULES := \
 	c_smartcard.c \
 	c_user.c \
+	c_shiftid.c \
 	c_net.c \
 	c_cgroups.c \
 	c_vol.c \

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -28,6 +28,7 @@ SANITIZERS ?= n
 CC_MODE ?= n
 WCAST_ALIGN ?= y
 OCI ?= n
+IDMAPPED ?= n
 
 TRUSTME_HARDWARE := x86
 
@@ -115,6 +116,21 @@ SRC_FILES := main.c \
 	audit.c
 
 # module order is crucial
+ifeq ($(IDMAPPED),y)
+SRC_CMODULES := \
+	c_smartcard.c \
+	c_user.c \
+	c_idmapped.c \
+	c_net.c \
+	c_cgroups.c \
+	c_vol.c \
+	c_service.c \
+	c_run.c \
+	c_time.c \
+	c_audit.c \
+	c_cap.c \
+	c_uevent.c
+else
 SRC_CMODULES := \
 	c_smartcard.c \
 	c_user.c \
@@ -129,6 +145,7 @@ SRC_CMODULES := \
 	c_audit.c \
 	c_cap.c \
 	c_uevent.c
+endif
 
 ifeq ($(OCI),y)
     LOCAL_CFLAGS += -DOCI -I${HOME}/rcs/libocispec/src

--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -1172,7 +1172,8 @@ c_cgroups_start_pre_exec(void *cgroupsp)
 			}
 		}
 
-		if (container_shift_ids(cgroups->container, subsys_child_path, false)) {
+		if (container_shift_ids(cgroups->container, subsys_child_path, subsys_child_path,
+					NULL)) {
 			ERROR("Could not shift ids of cgroup subsys for userns");
 			mem_free0(cgroup_tasks);
 			mem_free0(subsys_child_path);

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -27,6 +27,7 @@
 
 #include <fcntl.h>
 #include <linux/magic.h>
+#include <linux/types.h>
 #include <sys/mount.h>
 #include <sys/syscall.h>
 #include <sys/vfs.h>

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -450,14 +450,14 @@ kernel_version_check(char *version)
 {
 	struct utsname buf;
 	char ignore[65];
-	int main, major, main_to_check, major_to_check;
+	int _main, _major, main_to_check, major_to_check;
 
 	uname(&buf);
 
 	ASSERT(sscanf(version, "%d.%d%s", &main_to_check, &major_to_check, ignore) >= 2);
-	ASSERT(sscanf(buf.release, "%d.%d.%s", &main, &major, ignore) == 3);
+	ASSERT(sscanf(buf.release, "%d.%d.%s", &_main, &_major, ignore) == 3);
 
-	return (main == main_to_check) ? major >= major_to_check : main >= main_to_check;
+	return (_main == main_to_check) ? _major >= major_to_check : _main >= main_to_check;
 }
 
 static int

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -799,7 +799,7 @@ c_idmapped_umount_dir_cb(const char *path, const char *file, UNUSED void *data)
 	} else {
 		INFO("No mount point '%s'", file_to_umount);
 	}
-	mem_free(file_to_umount);
+	mem_free0(file_to_umount);
 	return 0;
 }
 

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -1,0 +1,829 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2022 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+#define _GNU_SOURCE
+
+#define MOD_NAME "c_idmapped"
+
+#include <fcntl.h>
+#include <linux/magic.h>
+#include <sys/mount.h>
+#include <sys/syscall.h>
+#include <sys/vfs.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/file.h"
+#include "common/dir.h"
+#include "container.h"
+
+#define IDMAPPED_SRC_DIR "/tmp/idmapped_mnts"
+#define UID_RANGE 100000
+
+/**************************/
+#ifndef MOUNT_ATTR_RDONLY
+#define MOUNT_ATTR_RDONLY 0x00000001
+#endif
+
+#ifndef MOUNT_ATTR_NOSUID
+#define MOUNT_ATTR_NOSUID 0x00000002
+#endif
+
+#ifndef MOUNT_ATTR_NOEXEC
+#define MOUNT_ATTR_NOEXEC 0x00000008
+#endif
+
+#ifndef MOUNT_ATTR_NODIRATIME
+#define MOUNT_ATTR_NODIRATIME 0x00000080
+#endif
+
+#ifndef MOUNT_ATTR__ATIME
+#define MOUNT_ATTR__ATIME 0x00000070
+#endif
+
+#ifndef MOUNT_ATTR_RELATIME
+#define MOUNT_ATTR_RELATIME 0x00000000
+#endif
+
+#ifndef MOUNT_ATTR_NOATIME
+#define MOUNT_ATTR_NOATIME 0x00000010
+#endif
+
+#ifndef MOUNT_ATTR_STRICTATIME
+#define MOUNT_ATTR_STRICTATIME 0x00000020
+#endif
+
+#ifndef MOUNT_ATTR_IDMAP
+#define MOUNT_ATTR_IDMAP 0x00100000
+#endif
+
+#ifndef AT_RECURSIVE
+#define AT_RECURSIVE 0x8000
+#endif
+
+// clang-format off
+#ifndef __NR_mount_setattr
+	#if defined __alpha__
+		#define __NR_mount_setattr 552
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32        /* o32 */
+			#define __NR_mount_setattr (442 + 4000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32       /* n32 */
+			#define __NR_mount_setattr (442 + 6000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64        /* n64 */
+			#define __NR_mount_setattr (442 + 5000)
+		#endif
+	#elif defined __ia64__
+		#define __NR_mount_setattr (442 + 1024)
+	#else
+		#define __NR_mount_setattr 442
+	#endif
+// clang-format on
+
+struct mount_attr {
+	__u64 attr_set;
+	__u64 attr_clr;
+	__u64 propagation;
+	__u64 userns_fd;
+};
+#endif
+
+#ifndef OPEN_TREE_CLONE
+#define OPEN_TREE_CLONE 1
+#endif
+
+#ifndef OPEN_TREE_CLOEXEC
+#define OPEN_TREE_CLOEXEC O_CLOEXEC
+#endif
+
+// clang-format off
+#ifndef __NR_open_tree
+	#if defined __alpha__
+		#define __NR_open_tree 538
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32        /* o32 */
+			#define __NR_open_tree 4428
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32       /* n32 */
+			#define __NR_open_tree 6428
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64        /* n64 */
+			#define __NR_open_tree 5428
+		#endif
+	#elif defined __ia64__
+		#define __NR_open_tree (428 + 1024)
+	#else
+		#define __NR_open_tree 428
+	#endif
+#endif
+// clang-format on
+
+#ifndef MOVE_MOUNT_F_SYMLINKS
+#define MOVE_MOUNT_F_SYMLINKS 0x00000001
+#endif
+
+#ifndef MOVE_MOUNT_F_AUTOMOUNTS
+#define MOVE_MOUNT_F_AUTOMOUNTS 0x00000002
+#endif
+
+#ifndef MOVE_MOUNT_F_EMPTY_PATH
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+#endif
+
+#ifndef MOVE_MOUNT_T_SYMLINKS
+#define MOVE_MOUNT_T_SYMLINKS 0x00000010
+#endif
+
+#ifndef MOVE_MOUNT_T_AUTOMOUNTS
+#define MOVE_MOUNT_T_AUTOMOUNTS 0x00000020
+#endif
+
+#ifndef MOVE_MOUNT_T_EMPTY_PATH
+#define MOVE_MOUNT_T_EMPTY_PATH 0x00000040
+#endif
+
+#ifndef MOVE_MOUNT__MASK
+#define MOVE_MOUNT__MASK 0x00000077
+#endif
+
+// clang-format off
+#ifndef __NR_move_mount
+	#if defined __alpha__
+		#define __NR_move_mount 539
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32
+			#define __NR_move_mount 4429
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32
+			#define __NR_move_mount 6429
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64
+			#define __NR_move_mount 5429
+		#endif
+	#elif defined __ia64__
+		#define __NR_move_mount (428 + 1024)
+	#else
+		#define __NR_move_mount 429
+	#endif
+#endif
+// clang-format on
+
+static int
+mount_setattr(int dirfd, const char *path, unsigned int flags, struct mount_attr *attr, size_t size)
+{
+	return syscall(__NR_mount_setattr, dirfd, path, flags, attr, size);
+}
+
+static int
+open_tree(int dirfd, const char *path, unsigned int flags)
+{
+	return syscall(__NR_open_tree, dirfd, path, flags);
+}
+
+static int
+move_mount(int from_dirfd, const char *from_path, int to_dirfd, const char *to_path,
+	   unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dirfd, from_path, to_dirfd, to_path, flags);
+}
+/**************************/
+
+struct c_idmapped_mnt {
+	char *target;
+	char *src;
+	int mapped_tree_fd;
+	char *ovl_lower;
+	char *ovl_upper;
+	bool bind_in_child;
+};
+
+/* idmapped structure with specific directory mappings */
+typedef struct c_idmapped {
+	container_t *container; //!< container which the c_idmapped struct is associated to
+	list_t *mapped_mnts;	//idmapped mounts (c_idmapped_mnt) to be mounted in userns
+	int src_index;
+	bool is_dev_mounted; // checks if the bind mount for dev is already performed
+} c_idmapped_t;
+
+static void
+c_idmapped_mnt_free(struct c_idmapped_mnt *mnt)
+{
+	IF_NULL_RETURN_ERROR(mnt);
+	mem_free0(mnt->src);
+	mem_free0(mnt->target);
+	if (mnt->ovl_lower)
+		mem_free0(mnt->ovl_lower);
+	if (mnt->ovl_upper)
+		mem_free0(mnt->ovl_upper);
+	mem_free0(mnt);
+}
+
+/**
+ * This function allocates a new c_idmapped_t instance, associated to a specific container object.
+ * @return the c_idmapped_t idmapped structure which holds idmapped mounts for a container.
+ */
+static void *
+c_idmapped_new(compartment_t *compartment)
+{
+	ASSERT(compartment);
+	IF_NULL_RETVAL(compartment_get_extension_data(compartment), NULL);
+
+	c_idmapped_t *idmapped = mem_new0(c_idmapped_t, 1);
+	idmapped->container = compartment_get_extension_data(compartment);
+	idmapped->is_dev_mounted = false;
+
+	TRACE("new c_idmapped struct was allocated");
+
+	return idmapped;
+}
+
+static void
+c_idmapped_free(void *idmappedp)
+{
+	c_idmapped_t *idmapped = idmappedp;
+	ASSERT(idmapped);
+	mem_free0(idmapped);
+}
+
+static int
+c_idmapped_mnt_apply_mapping(struct c_idmapped_mnt *mnt, int userns_fd)
+{
+	ASSERT(mnt);
+
+	struct mount_attr attr = { 0 };
+	attr.userns_fd = userns_fd;
+	attr.attr_set = MOUNT_ATTR_IDMAP;
+
+	if ((mnt->mapped_tree_fd = open_tree(
+		     -1, mnt->src, OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC | AT_EMPTY_PATH)) < 0) {
+		ERROR_ERRNO("Could not open_tree dir '%s' for container start", mnt->src);
+		goto error;
+	}
+
+	if (mount_setattr(mnt->mapped_tree_fd, "", AT_EMPTY_PATH, &attr,
+			  sizeof(struct mount_attr))) {
+		ERROR_ERRNO("Could not setattr for the new dir '%s' for container start", mnt->src);
+		close(mnt->mapped_tree_fd);
+		goto error;
+	}
+
+	INFO("Sucessfully applied idmapping from src dir %s on fd=%d for %s", mnt->src,
+	     mnt->mapped_tree_fd, mnt->target);
+
+	close(userns_fd);
+	return 0;
+
+error:
+	if (userns_fd > 0)
+		close(userns_fd);
+	return -1;
+}
+
+static int
+c_idmapped_chown_dir_cb(const char *path, const char *file, void *data)
+{
+	struct stat s;
+	int ret = 0;
+	c_idmapped_t *idmapped = data;
+	ASSERT(idmapped);
+
+	char *file_to_chown = mem_printf("%s/%s", path, file);
+	if (lstat(file_to_chown, &s) == -1) {
+		mem_free0(file_to_chown);
+		return -1;
+	}
+
+	int container_uid = container_get_uid(idmapped->container);
+
+	// modulo operation avoids shifting twice
+	uid_t uid = s.st_uid % UID_RANGE + container_uid;
+	gid_t gid = s.st_gid % UID_RANGE + container_uid;
+
+	if (file_is_dir(file_to_chown)) {
+		TRACE("Path %s is dir", file_to_chown);
+		if (dir_foreach(file_to_chown, &c_idmapped_chown_dir_cb, idmapped) < 0) {
+			ERROR_ERRNO("Could not chown all dir contents in '%s'", file_to_chown);
+			ret--;
+		}
+		if (chown(file_to_chown, uid, gid) < 0) {
+			ERROR_ERRNO("Could not chown dir '%s' to (%d:%d)", file_to_chown, uid, gid);
+			ret--;
+		}
+	} else {
+		if (lchown(file_to_chown, uid, gid) < 0) {
+			ERROR_ERRNO("Could not chown file '%s' to (%d:%d)", file_to_chown, uid,
+				    gid);
+			ret--;
+		}
+	}
+	TRACE("Chown file '%s' to (%d:%d) (uid_start %d)", file_to_chown, uid, gid, container_uid);
+
+	// chown .
+	if (chown(path, uid, gid) < 0) {
+		ERROR_ERRNO("Could not chown dir '%s' to (%d:%d)", path, uid, gid);
+		ret--;
+	}
+	mem_free0(file_to_chown);
+	return ret;
+}
+
+static int
+c_idmapped_mount_ovl(const char *overlayfs_mount_dir, const char *target, const char *ovl_lower,
+		     bool in_child)
+{
+	char *lower_dir = mem_printf("%s/lower", overlayfs_mount_dir);
+	char *upper_dir = mem_printf("%s/upper", overlayfs_mount_dir);
+	char *work_dir = mem_printf("%s/work", overlayfs_mount_dir);
+
+	DEBUG("Mounting overlayfs: work_dir=%s, upper_dir=%s, lower_dir=%s, target dir=%s",
+	      work_dir, upper_dir, ovl_lower, target);
+
+	struct statfs ovl_statfs;
+	statfs(overlayfs_mount_dir, &ovl_statfs);
+
+	// overmount tmpfs within user namespace
+	if (in_child && (TMPFS_MAGIC == ovl_statfs.f_type)) {
+		INFO("overmounting existing tmpfs with tmpfs in userns on '%s'.",
+		     overlayfs_mount_dir);
+		if (mount(NULL, overlayfs_mount_dir, "tmpfs", 0, NULL) < 0) {
+			ERROR_ERRNO("Could not mount tmpfs to %s", overlayfs_mount_dir);
+			goto error;
+		}
+	}
+
+	// needed for tmpfs in user namespace (child) as well as tmpfs of
+	// fallback mechanism where lower image is read only and a temporary
+	// upper tmpfs for chowning is used
+	if (dir_mkdir_p(upper_dir, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir upper dir %s", upper_dir);
+		goto error;
+	}
+	if (dir_mkdir_p(work_dir, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir work dir %s", work_dir);
+		goto error;
+	}
+
+	if (strcmp(ovl_lower, lower_dir) != 0) {
+		if (file_is_link(lower_dir))
+			unlink(lower_dir);
+		if (symlink(ovl_lower, lower_dir) < 0) {
+			ERROR_ERRNO("Failed to created link to %s on %s", ovl_lower, lower_dir);
+			mem_free0(lower_dir);
+			lower_dir = mem_strdup(ovl_lower);
+		}
+		if (file_is_link(lower_dir))
+			INFO("Sucessfully created link to %s on %s", ovl_lower, lower_dir);
+	}
+
+	DEBUG("Mounting overlayfs: work_dir=%s, upper_dir=%s, lower_dir=%s, target dir=%s",
+	      work_dir, upper_dir, lower_dir, target);
+	// create mount option string (try to mask absolute paths)
+	char *cwd = get_current_dir_name();
+	char *overlayfs_options;
+	if (chdir(overlayfs_mount_dir)) {
+		overlayfs_options = mem_printf("lowerdir=%s,upperdir=%s,workdir=%s,metacopy=on",
+					       lower_dir, upper_dir, work_dir);
+		INFO("chdir failed: old_wdir: %s, mount_cwd: %s, overlay_options: %s ", cwd,
+		     overlayfs_mount_dir, overlayfs_options);
+	} else {
+		overlayfs_options =
+			mem_strdup("lowerdir=lower,upperdir=upper,workdir=work,metacopy=on");
+		INFO("old_wdir: %s, mount_cwd: %s, overlay_options: %s ", cwd, overlayfs_mount_dir,
+		     overlayfs_options);
+	}
+	INFO("mount_dir: %s", target);
+	// mount overlayfs to dir
+	if (mount("overlay", target, "overlay", 0, overlayfs_options) < 0) {
+		ERROR_ERRNO("Could not mount overlay");
+		mem_free0(overlayfs_options);
+		if (chdir(cwd))
+			WARN("Could not change back to former cwd %s", cwd);
+		mem_free0(cwd);
+		goto error;
+	}
+	mem_free0(overlayfs_options);
+	if (chdir(cwd))
+		WARN("Could not change back to former cwd %s", cwd);
+	mem_free0(cwd);
+	mem_free0(lower_dir);
+	mem_free0(upper_dir);
+	mem_free0(work_dir);
+	return 0;
+error:
+	if (file_is_link(lower_dir)) {
+		if (unlink(lower_dir))
+			WARN_ERRNO("could not remove temporary link %s", lower_dir);
+	}
+	mem_free0(lower_dir);
+	mem_free0(upper_dir);
+	mem_free0(work_dir);
+	return -1;
+}
+
+static bool
+kernel_version_check(char *version)
+{
+	struct utsname buf;
+	char ignore[65];
+	int main, major, main_to_check, major_to_check;
+
+	uname(&buf);
+
+	ASSERT(sscanf(version, "%d.%d%s", &main_to_check, &major_to_check, ignore) >= 2);
+	ASSERT(sscanf(buf.release, "%d.%d.%s", &main, &major, ignore) == 3);
+
+	return (main == main_to_check) ? major >= major_to_check : main >= main_to_check;
+}
+
+static int
+c_idmapped_prepare_dir(c_idmapped_t *idmapped, struct c_idmapped_mnt *mnt, const char *dir)
+{
+	ASSERT(idmapped && mnt && dir);
+
+	// if kernel is to old and does not support idmapped mounts just chown the files
+	// and do bind mounts
+	int container_uid = container_get_uid(idmapped->container);
+	struct statfs dir_statfs;
+	statfs(dir, &dir_statfs);
+
+	if (!kernel_version_check("6.0")) {
+		if (dir_statfs.f_flags & MS_RDONLY) {
+			char *tmpfs_dir =
+				mem_printf("%s/%s/tmp%d", IDMAPPED_SRC_DIR,
+					   uuid_string(container_get_uuid(idmapped->container)),
+					   idmapped->src_index);
+			if (dir_mkdir_p(tmpfs_dir, 0777) < 0) {
+				ERROR_ERRNO("Could not mkdir idmapped dir %s", tmpfs_dir);
+				mem_free0(tmpfs_dir);
+				return -1;
+			}
+			if (mount(NULL, tmpfs_dir, "tmpfs", 0, NULL) < 0) {
+				ERROR_ERRNO("Could not mount tmpfs to %s", tmpfs_dir);
+				mem_free0(tmpfs_dir);
+				return -1;
+			}
+			if (c_idmapped_mount_ovl(tmpfs_dir, dir, dir, false)) {
+				ERROR("Failed to mount ovl '%s' (lower='%s') in userns on '%s'",
+				      tmpfs_dir, dir, dir);
+				mem_free0(tmpfs_dir);
+				return -1;
+			}
+			mem_free0(tmpfs_dir);
+		}
+		if (chown(dir, container_uid, container_uid) < 0) {
+			ERROR_ERRNO("Could not chown mnt point '%s' to (%d:%d)", dir, container_uid,
+				    container_uid);
+			return -1;
+		}
+		if (dir_foreach(dir, &c_idmapped_chown_dir_cb, idmapped) < 0) {
+			ERROR("Could not chown %s to target uid:gid (%d:%d)", dir, container_uid,
+			      container_uid);
+			return -1;
+		}
+
+		if (dir_statfs.f_flags & MS_RDONLY) {
+			if (mount("none", dir, "none", MS_REMOUNT | MS_RDONLY, NULL) < 0) {
+				ERROR_ERRNO("Could not remount tmpfs on %s", dir);
+				return -1;
+			}
+		}
+	}
+
+	mnt->src = mem_printf("%s/%s/src/%d", IDMAPPED_SRC_DIR,
+			      uuid_string(container_get_uuid(idmapped->container)),
+			      idmapped->src_index++);
+
+	if (dir_mkdir_p(mnt->src, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir mapped dir %s", mnt->src);
+		return -1;
+	}
+
+	if (mount(dir, mnt->src, NULL, MS_BIND, NULL) < 0) {
+		ERROR_ERRNO("Could not bind mount image origin %s on src %s", dir, mnt->src);
+		return -1;
+	}
+
+	if (!kernel_version_check("6.0"))
+		return 0;
+
+	/*
+	 * In case of dev, we cannot use user namespace mounts since the kernel
+	 * always implcitly sets the SB_I_NODEV flag for filesystems mounted
+	 * in non-inital userns. Thus, we just bind mounted it and return here.
+	 */
+	if (strlen(mnt->target) >= 4 && !strcmp(strrchr(mnt->target, '\0') - 4, "/dev")) {
+		if (chown(dir, container_uid, container_uid) < 0) {
+			ERROR_ERRNO("Could not chown mnt point '%s' to (%d:%d)", dir, container_uid,
+				    container_uid);
+			return -1;
+		}
+		idmapped->is_dev_mounted = true;
+		mnt->bind_in_child = true;
+		mnt->mapped_tree_fd = -1;
+		return 0;
+	}
+
+	if (TMPFS_MAGIC == dir_statfs.f_type) {
+		mnt->mapped_tree_fd = -1;
+		return 0;
+	}
+
+	if (mnt->ovl_lower && !strcmp(mnt->ovl_lower, mnt->target)) {
+		mnt->mapped_tree_fd = -1;
+		return 0;
+	}
+
+	int userns_fd = -1;
+	if ((userns_fd = container_open_userns(idmapped->container)) == -1) {
+		ERROR_ERRNO("Could not open userns_fd for container start");
+		return -1;
+	}
+
+	return c_idmapped_mnt_apply_mapping(mnt, userns_fd);
+}
+
+static int
+c_idmapped_mount_idmapped(c_idmapped_t *idmapped, const char *src, const char *dst,
+			  const char *ovl_lower)
+{
+	struct c_idmapped_mnt *mnt = NULL;
+	struct c_idmapped_mnt *mnt_lower = NULL;
+
+	mnt = mem_new0(struct c_idmapped_mnt, 1);
+	mnt->target = mem_strdup(dst);
+
+	if (ovl_lower) {
+		// mount ovl in rootns if kernel is to old
+		if (!kernel_version_check("5.12")) {
+			if (c_idmapped_mount_ovl(src, src, ovl_lower, false)) {
+				ERROR("Failed to mount ovl '%s' (lower='%s') in rootns on '%s'",
+				      src, ovl_lower, dst);
+				goto error;
+			}
+			if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
+				ERROR_ERRNO("Could not bind ovl in rootns '%s' on %s", src, dst);
+				goto error;
+			}
+			mnt = mem_new0(struct c_idmapped_mnt, 1);
+			mnt->target = mem_strdup(dst);
+			// set shifted lower as ovl_lower
+			mnt->ovl_lower = NULL;
+			IF_TRUE_GOTO(c_idmapped_prepare_dir(idmapped, mnt, src) < 0, error);
+
+			idmapped->mapped_mnts = list_append(idmapped->mapped_mnts, mnt);
+			return 0;
+		}
+
+		// mount lower idmapped if not over mounting lower dir itself
+		if (!strcmp(ovl_lower, dst))
+			mnt->ovl_lower = mem_strdup(dst);
+		else {
+			mnt_lower = mem_new0(struct c_idmapped_mnt, 1);
+			mnt_lower->target =
+				mem_printf("%s/%s/ovl%d", IDMAPPED_SRC_DIR,
+					   uuid_string(container_get_uuid(idmapped->container)),
+					   idmapped->src_index);
+			if (dir_mkdir_p(mnt_lower->target, 0777) < 0) {
+				ERROR_ERRNO("Could not mkdir idmapped lower dir %s",
+					    mnt_lower->target);
+				goto error;
+			}
+
+			mnt_lower->ovl_lower = NULL;
+			IF_TRUE_GOTO(c_idmapped_prepare_dir(idmapped, mnt_lower, ovl_lower) < 0,
+				     error);
+
+			idmapped->mapped_mnts = list_append(idmapped->mapped_mnts, mnt_lower);
+
+			// set idmapped lower as ovl_lower
+			mnt->ovl_lower = mem_strdup(mnt_lower->target);
+		}
+	}
+
+	IF_TRUE_GOTO(c_idmapped_prepare_dir(idmapped, mnt, src) < 0, error);
+	if (ovl_lower) {
+		mnt->ovl_upper = mem_printf("%s/%s/ovl%d", IDMAPPED_SRC_DIR,
+					    uuid_string(container_get_uuid(idmapped->container)),
+					    idmapped->src_index);
+		if (dir_mkdir_p(mnt->ovl_upper, 0777) < 0) {
+			ERROR_ERRNO("Could not mkdir idmapped upper dir %s", mnt->ovl_upper);
+			goto error;
+		}
+	}
+
+	idmapped->mapped_mnts = list_append(idmapped->mapped_mnts, mnt);
+
+	return 0;
+
+error:
+	if (mnt)
+		c_idmapped_mnt_free(mnt);
+	if (mnt_lower)
+		c_idmapped_mnt_free(mnt_lower);
+	return -1;
+}
+
+/**
+ * Shifts or sets uid/gids of path using the parent ids for this c_idmapped_t
+ *
+ * Call this inside the parent user_ns.
+ */
+static int
+c_idmapped_shift_ids(void *idmappedp, const char *src, const char *dst, const char *ovl_lower)
+{
+	c_idmapped_t *idmapped = idmappedp;
+	ASSERT(idmapped);
+
+	/* We can skip this in case the container has no user ns */
+	if (!container_has_userns(idmapped->container))
+		return 0;
+
+	TRACE("uid %d, euid %d", getuid(), geteuid());
+
+	int uid = container_get_uid(idmapped->container);
+
+	// if we just got a single file chown this and return
+	if (file_exists(src) && !file_is_dir(src)) {
+		if (lchown(src, uid, uid) < 0) {
+			ERROR_ERRNO("Could not chown file '%s' to (%d:%d)", src, uid, uid);
+			goto error;
+		}
+		goto success;
+	}
+
+	bool is_dev = strlen(dst) >= 5 && !strcmp(strrchr(dst, '\0') - 4, "/dev");
+	bool is_cgroup = strstr(src, "/cgroup") != NULL;
+
+	// if cgroup subsys or dev just chown the files
+	if (is_dev || is_cgroup) {
+		if (dir_foreach(src, &c_idmapped_chown_dir_cb, idmapped) < 0) {
+			ERROR("Could not chown %s to target uid:gid (%d:%d)", src, uid, uid);
+			goto error;
+		}
+		if ((is_dev && idmapped->is_dev_mounted) || is_cgroup)
+			goto success;
+	}
+
+	if (dir_mkdir_p(IDMAPPED_SRC_DIR, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir %s", IDMAPPED_SRC_DIR);
+		return -1;
+	}
+	if (chmod(IDMAPPED_SRC_DIR, 00777) < 0) {
+		ERROR_ERRNO("Could not chmod %s", IDMAPPED_SRC_DIR);
+		goto error;
+	}
+
+	IF_TRUE_GOTO(c_idmapped_mount_idmapped(idmapped, src, dst, ovl_lower) < 0, error);
+success:
+
+	INFO("Successfully idmapped uids for '%s'", src);
+	return 0;
+error:
+	return -1;
+}
+
+static int
+c_idmapped_start_child(void *idmappedp)
+{
+	c_idmapped_t *idmapped = idmappedp;
+	ASSERT(idmapped);
+
+	/* We can skip this in case the container has no user ns */
+	if (!container_has_userns(idmapped->container))
+		return 0;
+
+	for (list_t *l = idmapped->mapped_mnts; l; l = l->next) {
+		struct c_idmapped_mnt *mnt = l->data;
+		ASSERT(mnt->src && mnt->target);
+
+		INFO("mounting mnt in usrns src='%s', target='%s', ovl_lower='%s', ovl_upper='%s'",
+		     mnt->src, mnt->target, mnt->ovl_lower ? mnt->ovl_lower : "-",
+		     mnt->ovl_upper ? mnt->ovl_upper : "-");
+
+		// if explictly set to bind inchild (e.g. /dev on tmpfs) or
+		// kernel does not support idmapped mounts just do bind mount
+		if (mnt->bind_in_child || (!kernel_version_check("6.0"))) {
+			if (mount(mnt->src, mnt->target, NULL, MS_BIND, NULL) < 0) {
+				ERROR_ERRNO("Could not bind mount src %s to %s", mnt->src,
+					    mnt->target);
+				goto error;
+			}
+			continue;
+		}
+
+		if (mnt->mapped_tree_fd > 0 &&
+		    move_mount(mnt->mapped_tree_fd, "", -1,
+			       mnt->ovl_upper ? mnt->ovl_upper : mnt->target,
+			       MOVE_MOUNT_F_EMPTY_PATH) == -1) {
+			ERROR_ERRNO("Could not move_mount %s on %s for container start", mnt->src,
+				    mnt->ovl_upper ? mnt->ovl_upper : mnt->target);
+			goto error;
+		} else {
+			INFO("Successfully move_mount %s on %s for container start", mnt->src,
+			     mnt->ovl_upper ? mnt->ovl_upper : mnt->target);
+		}
+
+		if (mnt->ovl_lower) {
+			if (c_idmapped_mount_ovl(mnt->ovl_upper, mnt->target, mnt->ovl_lower,
+						 true)) {
+				ERROR("Failed to mount ovl '%s' in userns on '%s'", mnt->ovl_upper,
+				      mnt->target);
+				goto error;
+			}
+		}
+	}
+
+	INFO("Mounting with idmapped user and gids succseeded.");
+	return 0;
+error:
+	return -COMPARTMENT_ERROR_USER;
+}
+
+static int
+c_idmapped_start_post_clone(void *idmappedp)
+{
+	c_idmapped_t *idmapped = idmappedp;
+	ASSERT(idmapped);
+
+	/* We can skip this in case the container has no user ns */
+	if (!container_has_userns(idmapped->container))
+		return 0;
+
+	int uid = container_get_uid(idmapped->container);
+	char *root_dir = container_get_rootdir(idmapped->container);
+	if (chown(root_dir, uid, uid) < 0) {
+		ERROR_ERRNO("Could not chown dir '%s' to (%d:%d)", root_dir, uid, uid);
+		return -COMPARTMENT_ERROR_USER;
+	}
+
+	return 0;
+}
+
+/**
+ * Cleans up the c_user_t struct.
+ */
+static void
+c_idmapped_cleanup(void *idmappedp, UNUSED bool is_rebooting)
+{
+	c_idmapped_t *idmapped = idmappedp;
+	ASSERT(idmapped);
+
+	for (list_t *l = idmapped->mapped_mnts; l; l = l->next) {
+		struct c_idmapped_mnt *mnt = l->data;
+		c_idmapped_mnt_free(mnt);
+	}
+	list_delete(idmapped->mapped_mnts);
+	idmapped->mapped_mnts = NULL;
+}
+
+static compartment_module_t c_idmapped_module = {
+	.name = MOD_NAME,
+	.compartment_new = c_idmapped_new,
+	.compartment_free = c_idmapped_free,
+	.compartment_destroy = NULL,
+	.start_post_clone_early = NULL,
+	.start_child_early = NULL,
+	.start_pre_clone = NULL,
+	.start_post_clone = c_idmapped_start_post_clone,
+	.start_pre_exec = NULL,
+	.start_post_exec = NULL,
+	.start_child = c_idmapped_start_child,
+	.start_pre_exec_child = NULL,
+	.stop = NULL,
+	.cleanup = c_idmapped_cleanup,
+	.join_ns = NULL,
+};
+
+static void INIT
+c_idmapped_init(void)
+{
+	// register this module in compartment.c
+	compartment_register_module(&c_idmapped_module);
+
+	// register relevant handlers implemented by this module
+	container_register_shift_ids_handler(MOD_NAME, c_idmapped_shift_ids);
+}

--- a/daemon/c_shiftid.c
+++ b/daemon/c_shiftid.c
@@ -107,17 +107,13 @@ c_shiftid_cleanup_marks_cb(const char *path, const char *file, UNUSED void *data
  * Cleans up the c_shiftid_t struct.
  */
 static void
-c_shiftid_cleanup(void *shiftidp, bool is_rebooting)
+c_shiftid_cleanup(void *shiftidp, UNUSED bool is_rebooting)
 {
 	c_shiftid_t *shiftid = shiftidp;
 	ASSERT(shiftid);
 
 	/* We can skip this in case the container has no user ns */
 	if (!container_has_userns(shiftid->container))
-		return;
-
-	/* skip on reboots of c0 */
-	if (is_rebooting && (cmld_containers_get_c0() == shiftid->container))
 		return;
 
 	// cleanup left-over marks in main cmld process
@@ -128,6 +124,8 @@ c_shiftid_cleanup(void *shiftidp, bool is_rebooting)
 	if (rmdir(path) < 0)
 		TRACE("Unable to remove %s", path);
 	mem_free0(path);
+
+	shiftid->is_dev_mounted = false;
 }
 
 /**

--- a/daemon/c_shiftid.c
+++ b/daemon/c_shiftid.c
@@ -1,0 +1,341 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2022 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#define MOD_NAME "c_shiftid"
+
+#include <sys/mount.h>
+#include <unistd.h>
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/file.h"
+#include "common/dir.h"
+#include "cmld.h"
+#include "container.h"
+
+#define SHIFTFS_DIR "/tmp/shiftfs"
+#define UID_RANGE 100000
+
+struct c_shiftid_mnt {
+	char *target;
+	char *mark;
+	bool is_root;
+};
+
+/* shiftid structure with specific directory mappings */
+typedef struct c_shiftid {
+	container_t *container; //!< container which the c_user struct is associated to
+	list_t *marks;		//marks (c_shiftid_mnt) to be mounted in userns
+	int mark_index;
+} c_shiftid_t;
+
+static void
+c_shiftid_mnt_free(struct c_shiftid_mnt *mnt)
+{
+	IF_NULL_RETURN_ERROR(mnt);
+	mem_free0(mnt->target);
+	mem_free0(mnt->mark);
+	mem_free0(mnt);
+}
+
+/**
+ * This function allocates a new c_shiftid_t instance, associated to a specific container object.
+ * @return the c_shiftid_t structure which holds shifted mounts for a container.
+ */
+static void *
+c_shiftid_new(compartment_t *compartment)
+{
+	ASSERT(compartment);
+	IF_NULL_RETVAL(compartment_get_extension_data(compartment), NULL);
+
+	c_shiftid_t *shiftid = mem_new0(c_shiftid_t, 1);
+	shiftid->container = compartment_get_extension_data(compartment);
+
+	TRACE("new c_shiftid struct was allocated");
+
+	return shiftid;
+}
+
+static int
+c_shiftid_cleanup_marks_cb(const char *path, const char *file, UNUSED void *data)
+{
+	char *mark = mem_printf("%s/%s", path, file);
+	if (file_is_mountpoint(mark)) {
+		if (umount2(mark, MNT_DETACH) < 0) {
+			WARN_ERRNO("Could not umount shift mark on %s", mark);
+			mem_free0(mark);
+			return -1;
+		}
+		if (rmdir(mark) < 0)
+			TRACE("Unable to remove %s", mark);
+		INFO("Cleanup mark '%s' done.", mark);
+	}
+	mem_free0(mark);
+	return 0;
+}
+
+/**
+ * Cleans up the c_shiftid_t struct.
+ */
+static void
+c_shiftid_cleanup(void *shiftidp, bool is_rebooting)
+{
+	c_shiftid_t *shiftid = shiftidp;
+	ASSERT(shiftid);
+
+	/* We can skip this in case the container has no user ns */
+	if (!container_has_userns(shiftid->container))
+		return;
+
+	/* skip on reboots of c0 */
+	if (is_rebooting && (cmld_containers_get_c0() == shiftid->container))
+		return;
+
+	// cleanup left-over marks in main cmld process
+	const char *uuid = uuid_string(container_get_uuid(shiftid->container));
+	char *path = mem_printf("%s/%s/mark", SHIFTFS_DIR, uuid);
+	if (dir_foreach(path, &c_shiftid_cleanup_marks_cb, NULL) < 0)
+		WARN("Could not release marks in '%s'", path);
+	if (rmdir(path) < 0)
+		TRACE("Unable to remove %s", path);
+	mem_free0(path);
+}
+
+/**
+ * Frees the c_shiftid_t structure
+ */
+static void
+c_shiftid_free(void *shiftidp)
+{
+	c_shiftid_t *shiftid = shiftidp;
+	ASSERT(shiftid);
+	mem_free0(shiftid);
+}
+
+static int
+c_shiftid_chown_dir_cb(const char *path, const char *file, void *data)
+{
+	struct stat s;
+	int ret = 0;
+	c_shiftid_t *shiftid = data;
+	ASSERT(shiftid);
+
+	char *file_to_chown = mem_printf("%s/%s", path, file);
+	if (lstat(file_to_chown, &s) == -1) {
+		mem_free0(file_to_chown);
+		return -1;
+	}
+
+	int container_uid = container_get_uid(shiftid->container);
+
+	// modulo operation avoids shifting twice
+	uid_t uid = s.st_uid % UID_RANGE + container_uid;
+	gid_t gid = s.st_gid % UID_RANGE + container_uid;
+
+	if (file_is_dir(file_to_chown)) {
+		TRACE("Path %s is dir", file_to_chown);
+		if (dir_foreach(file_to_chown, &c_shiftid_chown_dir_cb, shiftid) < 0) {
+			ERROR_ERRNO("Could not chown all dir contents in '%s'", file_to_chown);
+			ret--;
+		}
+		if (chown(file_to_chown, uid, gid) < 0) {
+			ERROR_ERRNO("Could not chown dir '%s' to (%d:%d)", file_to_chown, uid, gid);
+			ret--;
+		}
+	} else {
+		if (lchown(file_to_chown, uid, gid) < 0) {
+			ERROR_ERRNO("Could not chown file '%s' to (%d:%d)", file_to_chown, uid,
+				    gid);
+			ret--;
+		}
+	}
+	TRACE("Chown file '%s' to (%d:%d) (uid_start %d)", file_to_chown, uid, gid, container_uid);
+
+	// chown .
+	if (chown(path, uid, gid) < 0) {
+		ERROR_ERRNO("Could not chown dir '%s' to (%d:%d)", path, uid, gid);
+		ret--;
+	}
+	mem_free0(file_to_chown);
+	return ret;
+}
+
+/**
+ * Shifts or sets uid/gids of path using the parent ids for this c_shiftid_t
+ *
+ * Call this inside the parent user_ns.
+ */
+static int
+c_shiftid_shift_ids(void *shiftidp, const char *path, bool is_root)
+{
+	c_shiftid_t *shiftid = shiftidp;
+	ASSERT(shiftid);
+
+	/* We can skip this in case the container has no user ns */
+	if (!container_has_userns(shiftid->container))
+		return 0;
+
+	TRACE("uid %d, euid %d", getuid(), geteuid());
+
+	int container_uid = container_get_uid(shiftid->container);
+
+	// if we just got a single file chown this and return
+	if (file_exists(path) && !file_is_dir(path)) {
+		if (lchown(path, container_uid, container_uid) < 0) {
+			ERROR_ERRNO("Could not chown file '%s' to (%d:%d)",
+				    path, container_uid, container_uid);
+			goto error;
+		}
+		goto success;
+	}
+
+	// if cgroup subsys or dev just chown the files
+	if ((strlen(path) >= 5 && !strcmp(strrchr(path, '\0') - 4, "/dev")) ||
+	    (strstr(path, "/cgroup") != NULL)) {
+		if (dir_foreach(path, &c_shiftid_chown_dir_cb, shiftid) < 0) {
+			ERROR("Could not chown %s to target uid:gid (%d:%d)", path, container_uid,
+			      container_uid);
+			goto error;
+		}
+		goto success;
+	}
+
+	// if kernel does not support shiftfs just chown the files
+	// and do bind mounts
+	if (!cmld_is_shiftfs_supported()) {
+		if (chown(path, container_uid, container_uid) < 0) {
+			ERROR_ERRNO("Could not chown mnt point '%s' to (%d:%d)", path,
+				    container_uid, container_uid);
+			goto error;
+		}
+		if (dir_foreach(path, &c_shiftid_chown_dir_cb, shiftid) < 0) {
+			ERROR("Could not chown %s to target uid:gid (%d:%d)",
+			      path, container_uid, container_uid);
+			goto error;
+		}
+	}
+
+	// create mountpoints for lower and upper dev
+	if (dir_mkdir_p(SHIFTFS_DIR, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir %s", SHIFTFS_DIR);
+		goto error;
+	}
+	if (chmod(SHIFTFS_DIR, 00777) < 0) {
+		ERROR_ERRNO("Could not chmod %s", SHIFTFS_DIR);
+		goto error;
+	}
+
+	struct c_shiftid_mnt *mnt = mem_new0(struct c_shiftid_mnt, 1);
+	mnt->target = mem_strdup(path);
+	mnt->mark =
+		mem_printf("%s/%s/mark/%d", SHIFTFS_DIR,
+			   uuid_string(container_get_uuid(shiftid->container)), shiftid->mark_index++);
+	mnt->is_root = is_root;
+	if (dir_mkdir_p(mnt->mark, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir shiftfs dir %s", mnt->mark);
+		c_shiftid_mnt_free(mnt);
+		goto error;
+	}
+	/*
+	 * In case shiftfs is not supported we use MS_BIND flag to just bind
+	 * mount the chowned directories to the new mount tree.
+	 * If MS_BIND flag is used, fs paramter and other options are ignored
+	 * by the mount system call.
+	 */
+	if (mount(path, mnt->mark, "shiftfs", cmld_is_shiftfs_supported() ? 0 : MS_BIND,
+		  "mark") < 0) {
+		ERROR_ERRNO("Could not mark shiftfs origin %s on mark %s", path, mnt->mark);
+		c_shiftid_mnt_free(mnt);
+		goto error;
+	}
+
+	shiftid->marks = list_append(shiftid->marks, mnt);
+
+success:
+
+	INFO("Successfully shifted uids for '%s'", path);
+	return 0;
+error:
+	return -1;
+}
+
+static int
+c_shiftid_shift_mounts(void *shiftidp)
+{
+	c_shiftid_t *shiftid = shiftidp;
+	ASSERT(shiftid);
+
+	/* Skip this, if the container doesn't have a user namespace */
+	if (!container_has_userns(shiftid->container))
+		return 0;
+
+	TRACE("uid %d, euid %d", getuid(), geteuid());
+	for (list_t *l = shiftid->marks; l; l = l->next) {
+		struct c_shiftid_mnt *mnt = l->data;
+
+		// mount the shifted user ids to new root
+		IF_TRUE_RETVAL(dir_mkdir_p(mnt->target, 0777) < 0, -1);
+		if (mount(mnt->mark, mnt->target, "shiftfs",
+			  cmld_is_shiftfs_supported() ? 0 : MS_BIND, NULL) < 0) {
+			ERROR_ERRNO("Could not remount shiftfs mark %s to %s", mnt->mark,
+				    mnt->target);
+			return -1;
+		} else {
+			INFO("Successfully shifted root uid/gid for userns mount %s",
+			     mnt->target);
+		}
+	}
+
+	return 0;
+}
+
+
+
+static compartment_module_t c_shiftid_module = {
+	.name = MOD_NAME,
+	.compartment_new = c_shiftid_new,
+	.compartment_free = c_shiftid_free,
+	.compartment_destroy = NULL,
+	.start_post_clone_early = NULL,
+	.start_child_early = NULL,
+	.start_pre_clone = NULL,
+	.start_post_clone = NULL,
+	.start_pre_exec = NULL,
+	.start_post_exec = NULL,
+	.start_child = NULL,
+	.start_pre_exec_child = NULL,
+	.stop = NULL,
+	.cleanup = c_shiftid_cleanup,
+	.join_ns = NULL,
+};
+
+static void INIT
+c_shiftid_init(void)
+{
+	// register this module in compartment.c
+	compartment_register_module(&c_shiftid_module);
+
+	// register relevant handlers implemented by this module
+	container_register_shift_ids_handler(MOD_NAME, c_shiftid_shift_ids);
+	container_register_shift_mounts_handler(MOD_NAME, c_shiftid_shift_mounts);
+}

--- a/daemon/c_shiftid.c
+++ b/daemon/c_shiftid.c
@@ -388,14 +388,14 @@ kernel_version_check(char *version)
 {
 	struct utsname buf;
 	char ignore[65];
-	int main, major, main_to_check, major_to_check;
+	int _main, _major, main_to_check, major_to_check;
 
 	uname(&buf);
 
 	ASSERT(sscanf(version, "%d.%d%s", &main_to_check, &major_to_check, ignore) >= 2);
-	ASSERT(sscanf(buf.release, "%d.%d.%s", &main, &major, ignore) == 3);
+	ASSERT(sscanf(buf.release, "%d.%d.%s", &_main, &_major, ignore) == 3);
 
-	return (main == main_to_check) ? major >= major_to_check : main >= main_to_check;
+	return (_main == main_to_check) ? _major >= major_to_check : _main >= main_to_check;
 }
 
 static int

--- a/daemon/c_uevent.c
+++ b/daemon/c_uevent.c
@@ -66,7 +66,7 @@ c_uevent_create_device_node(c_uevent_t *uevent, char *path, int major, int minor
 		goto err;
 	}
 shift:
-	if (container_shift_ids(uevent->container, path, false) < 0) {
+	if (container_shift_ids(uevent->container, path, path, NULL) < 0) {
 		ERROR("Failed to fixup uids for '%s' in usernamspace of container %s", path,
 		      container_get_name(uevent->container));
 		goto err;

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -867,9 +867,9 @@ c_vol_mount_image(c_vol_t *vol, const char *root, const mount_entry_t *mntent)
 				}
 				DEBUG("Successfully formatted new image %s using %s", img, dev);
 			}
-			if (!strcmp("btrfs", upper_fstype) &&
-			    !strncmp("subvol", mount_entry_get_mount_data(mntent), 6)) {
-				c_vol_btrfs_create_subvol(dev, mount_entry_get_mount_data(mntent));
+			if (!strcmp("btrfs", upper_fstype) && mount_data &&
+			    !strncmp("subvol", mount_data, 6)) {
+				c_vol_btrfs_create_subvol(dev, mount_data);
 			}
 		} break;
 

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1628,11 +1628,6 @@ c_vol_start_child(void *volp)
 
 	INFO("Switching to new rootfs in '%s'", vol->root);
 
-	if (container_shift_mounts(vol->container) < 0) {
-		ERROR_ERRNO("Mounting of shifting user and gids failed!");
-		goto error;
-	}
-
 	if (c_vol_mount_proc_and_sys(vol, vol->root) == -1) {
 		ERROR_ERRNO("Could not mount proc and sys");
 		goto error;

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -755,8 +755,6 @@ CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(setuid0, int, 0)
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(shift_ids, int, void *, const char *, const char *,
 				       const char *)
 CONTAINER_MODULE_FUNCTION_WRAPPER4_IMPL(shift_ids, int, 0, const char *, const char *, const char *)
-CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(shift_mounts, int, void *)
-CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(shift_mounts, int, 0)
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(get_uid, int, void *)
 CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(get_uid, int, 0)
 

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -752,8 +752,9 @@ container_get_usb_pin_entry(const container_t *container)
 /* Functions usually implemented and registered by c_user module */
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(setuid0, int, void *)
 CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(setuid0, int, 0)
-CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(shift_ids, int, void *, const char *, bool)
-CONTAINER_MODULE_FUNCTION_WRAPPER3_IMPL(shift_ids, int, 0, const char *, bool)
+CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(shift_ids, int, void *, const char *, const char *,
+				       const char *)
+CONTAINER_MODULE_FUNCTION_WRAPPER4_IMPL(shift_ids, int, 0, const char *, const char *, const char *)
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(shift_mounts, int, void *)
 CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(shift_mounts, int, 0)
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(get_uid, int, void *)

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -757,6 +757,8 @@ CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(shift_ids, int, void *, const char *, con
 CONTAINER_MODULE_FUNCTION_WRAPPER4_IMPL(shift_ids, int, 0, const char *, const char *, const char *)
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(get_uid, int, void *)
 CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(get_uid, int, 0)
+CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(open_userns, int, void *)
+CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(open_userns, int, 0)
 
 /* Functions usually implemented and registered by c_net module */
 CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(add_net_interface, int, void *, container_pnet_cfg_t *)

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -497,6 +497,14 @@ CONTAINER_MODULE_WRAPPER_DECLARE(shift_ids, int, const char *src, const char *ds
 CONTAINER_MODULE_WRAPPER_DECLARE(get_uid, int)
 
 /**
+ * Opens an file descriptor to a userns with the corresponding containers
+ * uid mappings.
+ *
+ * Returns the opened namespace fd
+ */
+CONTAINER_MODULE_WRAPPER_DECLARE(open_userns, int)
+
+/**
  * Returns the directory where the container's file system tree
  * is mounted in init mount namspace.
  */

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -490,13 +490,6 @@ CONTAINER_MODULE_WRAPPER_DECLARE(shift_ids, int, const char *src, const char *ds
 				 const char *ovl_lower)
 
 /**
- * Mounts all directories with shifted uid and gids inside the container's userns.
- *
- * Needs to be called before exec usually in a start_child handler.
- */
-CONTAINER_MODULE_WRAPPER_DECLARE(shift_mounts, int)
-
-/**
  * Returns the uid which is mapped to the root user inside the container
  *
  * if userns is enabled this would be a uid grater than 0.

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -486,7 +486,8 @@ CONTAINER_MODULE_WRAPPER_DECLARE(is_device_allowed, bool, int major, int minor)
  * with shifted ids in child. This is also be used to shift single files in the
  * in uevent module for container allowed devices.
  */
-CONTAINER_MODULE_WRAPPER_DECLARE(shift_ids, int, const char *path, bool is_root)
+CONTAINER_MODULE_WRAPPER_DECLARE(shift_ids, int, const char *src, const char *dst,
+				 const char *ovl_lower)
 
 /**
  * Mounts all directories with shifted uid and gids inside the container's userns.


### PR DESCRIPTION
Use mainline idmapped mounts instead of shiftfs
This depends on idmapped squahsfs mounts which was also was submitted to mainline Linux 
(https://lore.kernel.org/all/20221024191552.55951-1-michael.weiss@aisec.fraunhofer.de/)
and will hopefully make it in 6.2. Meanwhile the old mechanism was refactored to a c_shiftid module
which remains default unless Make option IDMAPPED is set to 'y'