### PR TITLE
Backports: Fixes for daemon/c_vol and daemon/c_cgroups

### DIFF
--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -326,8 +326,7 @@ c_cgroups_devices_allow(c_cgroups_t *cgroups, const char *rule)
 
 	int *dev = c_cgroups_dev_from_rule(rule);
 	if (c_cgroups_list_contains_match(global_assigned_devs_list, dev)) {
-		WARN("Unable to allow rule %s: device busy (already assigned to another container)",
-		     rule);
+		WARN("Unable to allow rule %s", rule);
 		mem_free0(dev);
 		return 0;
 	}
@@ -344,8 +343,7 @@ c_cgroups_devices_assign(c_cgroups_t *cgroups, const char *rule)
 
 	int *dev = c_cgroups_dev_from_rule(rule);
 	if (c_cgroups_list_contains_match(global_allowed_devs_list, dev)) {
-		ERROR("Unable to exclusively assign device according to rule %s: device busy (already available to another container)",
-		      rule);
+		ERROR("Unable to exclusively assign device according to rule %s", rule);
 		mem_free0(dev);
 		return -1;
 	}


### PR DESCRIPTION
This PR backports fixes for /dev/pts and a misleading error message when assigning non-present devices