### PR TITLE
Fix compatibility with newer protoc-c versions

### DIFF
--- a/daemon/guestos_config.h
+++ b/daemon/guestos_config.h
@@ -32,13 +32,14 @@
  */
 
 #include "mount.h"
+#include "guestos.pb-c.h"
 
 #include <stdint.h>
 
 /**
  * A structure to present a guest operating system.
  */
-typedef struct _GuestOSConfig guestos_config_t;
+typedef GuestOSConfig guestos_config_t;
 
 /******************************************************************************/
 


### PR DESCRIPTION
Adapt typedef for GuestOSConfig to fit protoc-c generated source files from newer versions.

GuestOSConfig is a typedef already provided by protoc-c generated header files.
This was successfully tested on
- Debian Buster: protoc-c --version
protobuf-c 1.3.1
libprotoc 3.6.1

- Debian Bullseye: protoc-c --version
protobuf-c 1.3.3
libprotoc 3.12.4

- Debian sid: protoc-c --version
protobuf-c 1.4.1
libprotoc 3.12.4