### PR TITLE
common/ssl_util: Introduce AES functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ control/control
 daemon/cmld
 scd/scd
 service/cml-service-container
+control/cc_mode


### PR DESCRIPTION
Introduce functions for encryption and decryption with AES in ECB and CTR mode.

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>