### PR TITLE
Backports for OS version handling, recent protoc-c versions and the CI Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,9 @@ pipeline {
 									DEVELOPMENT_BUILD=n
 									CC_MODE=y
 								elif [ "schsm" = "${BUILDTYPE}" ];then
+									echo "Preparing Yocto workdir for CC Mode build with schsm support"
+									DEVELOPMENT_BUILD=n
+									CC_MODE=y
 									SANITIZERS=y
 									ENABLE_SCHSM="1"
 								else
@@ -281,7 +284,7 @@ pipeline {
 						echo "$PATH"
 						echo "Physhsm: ${PHYSHSM}"
 
-						bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --dir ${WORKSPACE} --builddir out-schsm --pki "${WORKSPACE}/out-schsm/test_certificates" --name "qemutme-sc" --ssh 2230 --kill --enable-schsm ${PHYSHSM} 12345678'
+						bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --mode ccmode --dir ${WORKSPACE} --builddir out-schsm --pki "${WORKSPACE}/out-schsm/test_certificates" --name "qemutme-sc" --ssh 2230 --kill --enable-schsm ${PHYSHSM} 12345678'
 					'''
 				}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,9 +131,7 @@ pipeline {
 									DEVELOPMENT_BUILD=n
 									CC_MODE=y
 								elif [ "schsm" = "${BUILDTYPE}" ];then
-									echo "Preparing Yocto workdir for CC Mode build with schsm support"
-									DEVELOPMENT_BUILD=n
-									CC_MODE=y
+									echo "Preparing Yocto workdir for ccmode build with schsm support"
 									SANITIZERS=y
 									ENABLE_SCHSM="1"
 								else
@@ -227,7 +225,7 @@ pipeline {
 				axes {
 					axis {
 						name 'BUILDTYPE'
-						values 'dev', 'production'
+						values 'dev', 'production', 'ccmode'
 					}
 				}
 				stages {
@@ -247,6 +245,8 @@ pipeline {
 										unstash 'img-dev'
 									} else if ("production" == env.BUILDTYPE){
 										unstash 'img-production'
+									} else if ("ccmode" == env.BUILDTYPE){
+										unstash 'img-ccmode'
 									} else {
 										error "Unkown build type"
 									}
@@ -258,10 +258,14 @@ pipeline {
 
 									if [ "dev" = "${BUILDTYPE}" ];then
 										echo "Testing \"dev\" image"
-										bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --skip-rootca --mode dev --dir ${WORKSPACE} --builddir out-${BUILDTYPE} --pki "${WORKSPACE}/out-${BUILDTYPE}/test_certificates" --name "qemutme-pr" --ssh 2228 --kill --vnc 41'
+										bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --skip-rootca --mode dev --dir ${WORKSPACE} --builddir out-${BUILDTYPE} --pki "${WORKSPACE}/out-${BUILDTYPE}/test_certificates" --name "qemutme-dev" --ssh 2228 --kill --vnc 41'
 									elif [ "production" = "${BUILDTYPE}" ];then
 										echo "Testing \"production\" image"
-										bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --skip-rootca --mode production --dir ${WORKSPACE} --builddir out-${BUILDTYPE} --pki "${WORKSPACE}/out-${BUILDTYPE}/test_certificates" --name "qemutme-dev" --ssh 2229 --kill --vnc 42'
+										bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --skip-rootca --mode production --dir ${WORKSPACE} --builddir out-${BUILDTYPE} --pki "${WORKSPACE}/out-${BUILDTYPE}/test_certificates" --name "qemutme-pr" --ssh 2229 --kill --vnc 42'
+									elif [ "ccmode" = "${BUILDTYPE}" ];then
+										echo "Testing \"ccmode\" image"
+										bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --skip-rootca --mode ccmode --dir ${WORKSPACE} --builddir out-${BUILDTYPE} --pki "${WORKSPACE}/out-${BUILDTYPE}/test_certificates" --name "qemutme-cc" --ssh 2230 --kill --vnc 43'
+
 									else
 										error "Unknown build type: ${BUILDTYPE}"
 									fi
@@ -284,7 +288,7 @@ pipeline {
 						echo "$PATH"
 						echo "Physhsm: ${PHYSHSM}"
 
-						bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --mode ccmode --dir ${WORKSPACE} --builddir out-schsm --pki "${WORKSPACE}/out-schsm/test_certificates" --name "qemutme-sc" --ssh 2230 --kill --enable-schsm ${PHYSHSM} 12345678'
+						bash -c '${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --mode dev --dir ${WORKSPACE} --builddir out-schsm --pki "${WORKSPACE}/out-schsm/test_certificates" --name "qemutme-sc" --ssh 2231 --kill --enable-schsm ${PHYSHSM} 12345678'
 					'''
 				}
 			}

--- a/common/logf.c
+++ b/common/logf.c
@@ -151,6 +151,11 @@ logf_message_hexdump(logf_prio_t prio, const void *b, size_t len, const char *fm
 	size_t i;
 	int n;
 
+	if (len > 1024) {
+		logf_write(prio, "Buffer too long for log");
+		return;
+	}
+
 	va_start(ap, fmt);
 	n = vsnprintf(buf, sizeof(buf), fmt, ap);
 	va_end(ap);
@@ -180,6 +185,11 @@ logf_message_file_hexdump(logf_prio_t prio, const char *file, int line, const vo
 	va_list ap;
 	size_t i;
 	int n;
+
+	if (len > 1024) {
+		logf_write(prio, "Buffer too long for log");
+		return;
+	}
 
 	n = snprintf(buf, sizeof(buf), "%s+%d: ", file, line);
 

--- a/control/Makefile
+++ b/control/Makefile
@@ -24,6 +24,7 @@ CC ?= gcc
 DEVELOPMENT_BUILD ?= y
 AGGRESSIVE_WARNINGS ?= y
 SANITIZERS ?= n
+CC_MODE ?= n
 
 LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -Icommon -O2
 LOCAL_CFLAGS += -pedantic -Wall -Wextra -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
@@ -70,11 +71,28 @@ SRC_FILES := \
 .PHONY: all
 all: control
 
+
+ifeq ($(CC_MODE),y)
 protobuf: container.proto control.proto guestos.proto common/logf.proto
-	protoc-c --c_out=. guestos.proto
-	protoc-c --c_out=. container.proto
+	echo "Using CC_MODE protos"
+	$(MAKE) -C cc_mode
+	ln -sf cc_mode/container.pb-c.c container.pb-c.c
+	ln -sf cc_mode/container.pb-c.h container.pb-c.h
+	ln -sf cc_mode/guestos.pb-c.c guestos.pb-c.c
+	ln -sf cc_mode/guestos.pb-c.h guestos.pb-c.h
 	protoc-c --c_out=. control.proto
 	$(MAKE) -C common protobuf
+
+else
+protobuf: container.proto control.proto guestos.proto common/logf.proto
+	echo "Using dev/production protos"
+	protoc-c --c_out=. container.proto
+	protoc-c --c_out=. control.proto
+	protoc-c --c_out=. guestos.proto
+	$(MAKE) -C common protobuf
+
+endif
+
 
 libcommon: 
 	$(MAKE) -C common libcommon

--- a/control/cc_mode
+++ b/control/cc_mode
@@ -1,0 +1,1 @@
+../daemon/cc_mode/

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -480,9 +480,19 @@ container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t
 
 	const char *os_name = container_config_get_guestos(conf);
 	DEBUG("New containers os name is %s", os_name);
-	os = guestos_mgr_get_latest_by_name(os_name, true);
+
+	// if signed config files are used, always load
+	// OS version specified in container config
+	if (cmld_uses_signed_configs()) {
+		os = guestos_mgr_get_by_version(os_name, container_config_get_guestos_version(conf),
+						true);
+	} else {
+		os = guestos_mgr_get_latest_by_name(os_name, true);
+	}
+
 	if (!os) {
-		WARN("Could not get GuestOS %s instance for container %s", os_name, name);
+		WARN("Could not get GuestOS %s instance for container %s with version v%" PRIu64,
+		     os_name, name, container_config_get_guestos_version(conf));
 		mem_free0(config_filename);
 		mem_free0(images_dir);
 		uuid_free(uuid);

--- a/daemon/guestos_config.h
+++ b/daemon/guestos_config.h
@@ -32,13 +32,14 @@
  */
 
 #include "mount.h"
+#include "guestos.pb-c.h"
 
 #include <stdint.h>
 
 /**
  * A structure to present a guest operating system.
  */
-typedef struct _GuestOSConfig guestos_config_t;
+typedef GuestOSConfig guestos_config_t;
 
 /******************************************************************************/
 

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -594,6 +594,40 @@ out:
 /******************************************************************************/
 
 guestos_t *
+guestos_mgr_get_by_version(const char *name, uint64_t version, bool complete)
+{
+	IF_NULL_RETVAL(name, NULL);
+
+	guestos_t *latest_os = NULL;
+	for (list_t *l = guestos_list; l; l = l->next) {
+		if (!strcmp(name, guestos_get_name(l->data))) {
+			guestos_t *os = l->data;
+			uint64_t v = guestos_get_version(os);
+
+			if (v != version) {
+				TRACE("Found correct os name, but with wrong version. Continuing!");
+				continue;
+			}
+
+			// TODO cache image complete result in guestos instance and get rid of check here?
+			if (complete && !guestos_images_are_complete(os, false)) {
+				audit_log_event(NULL, FSA, CMLD, GUESTOS_MGMT, "broken-update",
+						guestos_get_name(os), 0);
+				DEBUG("GuestOS %s v%" PRIu64
+				      " is incomplete (missing images) or broken, skipping.",
+				      guestos_get_name(os), v);
+				continue;
+			}
+
+			latest_os = os;
+			break;
+		}
+	}
+
+	return latest_os;
+}
+
+guestos_t *
 guestos_mgr_get_latest_by_name(const char *name, bool complete)
 {
 	IF_NULL_RETVAL(name, NULL);

--- a/daemon/guestos_mgr.h
+++ b/daemon/guestos_mgr.h
@@ -112,6 +112,20 @@ guestos_mgr_register_newca(unsigned char *cacert, size_t cacertlen);
 
 /******************************************************************************/
 
+/*
+ * Returns the GuestOS with the given name and version.
+ * If 'complete' is set, only complete GuestOS instances are considered,
+ * i.e. all shared images belonging to the GuestOS must be available on the device.
+ * Otherwise, all registered GuestOSes with the given name are considered.
+ * @param name	    the name of the GuestOS
+ * @param version	version of the GuestOS
+ * @param complete  whether to only consider complete GuestOSes with all images available on the device
+ * @return  a pointer to the found GuestOS instance or NULL if no matching GuestOS was found
+ *	    (Note: The returned pointer should NOT be free'd by the caller.)
+ */
+guestos_t *
+guestos_mgr_get_by_version(const char *name, uint64_t version, bool complete);
+
 /**
  * Returns the latest (by version) GuestOS with the given name.
  * If 'complete' is set, only complete GuestOS instances are considered,

--- a/scripts/ci/VM-container-commands.sh
+++ b/scripts/ci/VM-container-commands.sh
@@ -151,9 +151,9 @@ cmd_control_list_guestos() {
 
 cmd_control_create() {
 if [ -z "$2" ];then
-	do_test_cmd_output "/usr/sbin/control create \"$1\"" "uuids"
+	do_test_cmd_output "/usr/sbin/control create \"$1\"" "guest_os"
 else
-	do_test_cmd_output "/usr/sbin/control create \"$1\" \"$2\" \"$3\"" "uuids"
+	do_test_cmd_output "/usr/sbin/control create \"$1\" \"$2\" \"$3\"" "guest_os"
 fi
 
 sleep 5
@@ -201,20 +201,7 @@ cmd_control_reboot() {
 }
 
 cmd_control_get_guestos_version(){
-	CMD1="/usr/sbin/control list_guestos"
-	CMD2="/usr/sbin/control list_guestos | grep $1 -A 2"
-	CMD3="/usr/sbin/control list_guestos | grep $1 -A 2 | grep version\:"
-	CMD4="/usr/sbin/control list_guestos | grep $1 -A 2 | grep version\: | awk '{print \$2}'"
-	CMD5="/usr/sbin/control list_guestos | grep $1 -A 2 | grep version\: | awk '{print \$2}' | sort | tail -n 1"
-	OUTPUT1="$(ssh ${SSH_OPTS} "$CMD1")"
-	OUTPUT2="$(ssh ${SSH_OPTS} "$CMD2")"
-	OUTPUT3="$(ssh ${SSH_OPTS} "$CMD3")"
-	OUTPUT4="$(ssh ${SSH_OPTS} "$CMD4")"
-	OUTPUT5="$(ssh ${SSH_OPTS} "$CMD5")"
-
-	#echo $OUTPUT1
-	#echo $OUTPUT2
-	#echo $OUTPUT3
-	#echo $OUTPUT4
-	echo $OUTPUT5
+	CMD="/usr/sbin/control list_guestos | grep $1 -A 2 | grep version\: | awk '{print \$2}' | sort | tail -n 1"
+	OUTPUT="$(ssh ${SSH_OPTS} "$CMD")"
+	echo $OUTPUT
 }

--- a/scripts/ci/VM-container-tests.sh
+++ b/scripts/ci/VM-container-tests.sh
@@ -9,7 +9,7 @@ source "$(dirname "${CMDPATH}")/VM-container-commands.sh"
 
 export PATH="/sbin/:usr/sbin/:${PATH}"
 
-PROCESS_NAME="qemu-ccmode-ci"
+PROCESS_NAME="qemu-gyroid-ci"
 SSH_PORT=2223
 BUILD_DIR=""
 KILL_VM=false
@@ -120,7 +120,7 @@ cat > ./signedcontainer.conf << EOF
 name: "signedcontainer"
 guest_os: "trustx-coreos"
 guestos_version: $installed_guestos_version
-assign_dev: "c 4:2 rwm"
+assign_dev: "c 4:3 rwm"
 EOF
 
 
@@ -130,9 +130,8 @@ else
 cat > ./testcontainer.conf << EOF
 name: "testcontainer"
 guest_os: "trustx-coreos"
-assign_dev: "c 4:2 rwm"
 guestos_version: $installed_guestos_version 
-token_type: USB
+assign_dev: "c 4:2 rwm"
 EOF
 
 
@@ -140,7 +139,7 @@ cat > ./signedcontainer.conf << EOF
 name: "signedcontainer"
 guest_os: "trustx-coreos"
 guestos_version: $installed_guestos_version
-assign_dev: "c 4:2 rwm"
+assign_dev: "c 4:3 rwm"
 token_type: USB
 usb_configs {
   id: "04e6:5816"
@@ -151,10 +150,10 @@ usb_configs {
 EOF
 fi
 
-echo "STATUS: Created testcontainer.conf:"
+echo "STATUS: Prepared testcontainer.conf:"
 echo "$(cat ./testcontainer.conf)"
 
-echo "STATUS: Created testcontainer.conf:"
+echo "STATUS: Prepared signedcontainer.conf:"
 echo "$(cat ./signedcontainer.conf)"
 
 
@@ -571,7 +570,7 @@ start_vm
 
 
 # Retrieve VM host key
-echo "STATUS: Retrieveing VM host key"
+echo "STATUS: Retrieving VM host key"
 for I in $(seq 1 10) ;do
 	echo "STATUS: Scanning for VM host key on port $SSH_PORT"
 	if ssh-keyscan -T 10 -p $SSH_PORT -H 127.0.0.1 > ${PROCESS_NAME}.vm_key ;then
@@ -655,6 +654,8 @@ if [[ "$MODE" == "dev" ]];then
 	cmd_control_create "/tmp/testcontainer.conf"
 	cmd_control_list_container "testcontainer"
 
+	sync_to_disk
+
 	echo "Creating container:\n$(cat signedcontainer.conf)"
 	cmd_control_create "/tmp/signedcontainer.conf" "/tmp/signedcontainer.sig" "/tmp/signedcontainer.cert"
 	cmd_control_list_container "signedcontainer"
@@ -662,6 +663,7 @@ else
 	#cmd_control_create_error "/tmp/testcontainer.conf"
 	echo "Creating container:\n$(cat signedcontainer.conf)"
 	cmd_control_create "/tmp/signedcontainer.conf" "/tmp/signedcontainer.sig" "/tmp/signedcontainer.cert"
+	cmd_control_list_container "signedcontainer"
 fi
 
 sync_to_disk


### PR DESCRIPTION
This commit backports the following fixes from the dunfell branch
- Always use GuestOS version from container config when using signed config
- Adapt typedef to support recent protoc versions
- Enable CI tests for ccmode images 
