### PR TITLE
.gitignore: Ignore build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ cscope.out
 tags
 /**/compile_commands.json
 .vscode/
+*pb-c*
+*.o
+*.a
+control/control
+daemon/cmld
+scd/scd
+service/cml-service-container


### PR DESCRIPTION
This commit ignores files related to the build process such as pb-c.{h,c}, object files and binaries.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>