### PR TITLE
Correct portable format string for size_t

### DIFF
--- a/rattestation/attestation.c
+++ b/rattestation/attestation.c
@@ -100,7 +100,7 @@ attestation_verify_resp(Tpm2dToRemote *resp, RAttestationConfig *config, uint8_t
 	DEBUG("Hash Algorithm: SHA%d", config->halg * 8);
 
 	if (resp->n_pcr_values != config->n_pcr_values) {
-		ERROR("Number of configured PCR values (%lu) does not match responded PCR values (%lu)",
+		ERROR("Number of configured PCR values (%zu) does not match responded PCR values (%zu)",
 		      config->n_pcr_values, resp->n_pcr_values);
 		ret = false;
 		goto err;


### PR DESCRIPTION
The printed variables are of type size_t. size_t is a typedef for `long unsigned int` on 64bit architectures and `unsigned int` on 32bit architectures. This PR fixes the format string to correctly recognize the size of type size_t on all architectures and not always assume 64bit. This is required to fix compilation for the arm32 (e.g. colibri-imx6ull board) architecture.

Signed-off-by: Johannes Wiesboeck <johannes.wiesboeck@aisec.fraunhofer.de>