### PR TITLE
daemon/control: enable retrieve_logs command in CC_MODE

### DIFF
--- a/daemon/control.c
+++ b/daemon/control.c
@@ -773,7 +773,8 @@ control_check_command(control_t *control, const ControllerToDaemon *msg)
 	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_LIST_IFACES) ||
 	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_UPDATE_CONFIG) ||
 	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CHANGE_TOKEN_PIN) ||
-	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CMLD_HANDLES_PIN))) {
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CMLD_HANDLES_PIN) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_LAST_LOG))) {
 		TRACE("Received command %d is invalid in CC mode", msg->command);
 		return false;
 	}


### PR DESCRIPTION
This commit allows using the retrieve_losg command from a CC_MODE image as well

Signed-off-by: Corinna Lingstädt <corinna.lingstaedt@aisec.fraunhofer.de>