### PR TITLE
daemon/audit: avoid 'warning: the use of `mktemp' is dangerous'

### DIFF
--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -463,7 +463,7 @@ audit_do_send_record(const container_t *c)
 		return -1;
 	}
 
-	if (!strcmp("", mktemp(tmpfile))) {
+	if (-1 == mkstemp(tmpfile)) {
 		ERROR_ERRNO("Failed to generate temporary filename");
 		return -1;
 	}


### PR DESCRIPTION
We switched from mktemp() to mkstemp() for generating the temporary file name in audit_log_record(). This avoids the corresponding gcc warning.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>