### PR TITLE
scripts/ci/Dockerfile: Install missing HOSTTOOLS

### DIFF
--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster
 
 
 # Essentials
-RUN apt-get update && apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping libsdl1.2-dev xterm lsb-release libprotobuf-c1 libprotobuf-c-dev protobuf-compiler protobuf-c-compiler autoconf libtool libtool-bin re2c check rsync
+RUN apt-get update && apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping libsdl1.2-dev xterm lsb-release libprotobuf-c1 libprotobuf-c-dev protobuf-compiler protobuf-c-compiler autoconf libtool libtool-bin re2c check rsync lz4 zstd
 
 
 # CI


### PR DESCRIPTION
Yocto kirkstone requires lz4 and zstd as additional HOSTTOOLS. Install them into the Docker Container.

Signed-off-by: Johannes Wiesboeck <johannes.wiesboeck@aisec.fraunhofer.de>