### PR TITLE
treewide: fixed naming and contact information trustme -> gyroidos

### DIFF
--- a/Makefile_lsb
+++ b/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 # Container Management Layer
 
-This repository contains the daemons and tools of the trust|me Container Management Layer (CML).
+This repository contains the daemons and tools of the GyroidOS Container Management Layer (CML).
 The project documentation can by found on [gyroidos.github.io](https://gyroidos.github.io).
 
 ## Contributing
 
-This project is part of trust|me which enforces the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) on Pull Requests. It requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author and the name on your GitHub account.
+This project is part of GyroidOS which enforces the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) on Pull Requests. It requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author and the name on your GitHub account.
 
 The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 test_basic: control_pb2.py

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -19,7 +19,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 from thread import *

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2018 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 

--- a/common/audit.c
+++ b/common/audit.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef _GNU_SOURCE

--- a/common/audit.h
+++ b/common/audit.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef COMMON_AUDIT_H

--- a/common/audit.proto
+++ b/common/audit.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/common/cryptfs.c
+++ b/common/cryptfs.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _LARGEFILE64_SOURCE

--- a/common/cryptfs.h
+++ b/common/cryptfs.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/dir.c
+++ b/common/dir.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "dir.h"

--- a/common/dir.h
+++ b/common/dir.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/dm.c
+++ b/common/dm.c
@@ -1,6 +1,6 @@
 
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -19,7 +19,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/common/dm.h
+++ b/common/dm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef DM_H

--- a/common/event.c
+++ b/common/event.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/common/event.h
+++ b/common/event.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/fd.c
+++ b/common/fd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdint.h>

--- a/common/fd.h
+++ b/common/fd.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/file.c
+++ b/common/file.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE // for syncfs()

--- a/common/file.h
+++ b/common/file.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/hex.c
+++ b/common/hex.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdint.h>

--- a/common/hex.h
+++ b/common/hex.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef HEX_H_

--- a/common/list.c
+++ b/common/list.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/common/list.h
+++ b/common/list.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/logf.c
+++ b/common/logf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "macro.h"

--- a/common/logf.h
+++ b/common/logf.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/logf.proto
+++ b/common/logf.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/common/loopdev.c
+++ b/common/loopdev.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <sys/types.h>

--- a/common/loopdev.h
+++ b/common/loopdev.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/macro.h
+++ b/common/macro.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/macro.test.c
+++ b/common/macro.test.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 #include <limits.h>
 

--- a/common/mem.c
+++ b/common/mem.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/common/mem.h
+++ b/common/mem.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/mem.test.c
+++ b/common/mem.test.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "munit.h"

--- a/common/network.c
+++ b/common/network.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define LOGF_LOG_MIN_PRIO 2

--- a/common/network.h
+++ b/common/network.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/nl.c
+++ b/common/nl.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "nl.h"

--- a/common/nl.h
+++ b/common/nl.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /* @file nl.h

--- a/common/ns.c
+++ b/common/ns.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/common/ns.h
+++ b/common/ns.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/proc.c
+++ b/common/proc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/common/proc.h
+++ b/common/proc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef PROC_H

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "protobuf.h"

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/reboot.c
+++ b/common/reboot.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "reboot.h"

--- a/common/reboot.h
+++ b/common/reboot.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/sock.c
+++ b/common/sock.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/common/sock.h
+++ b/common/sock.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "ssl_util.h"

--- a/common/ssl_util.h
+++ b/common/ssl_util.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef P12UTIL_H

--- a/common/str.c
+++ b/common/str.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/common/str.h
+++ b/common/str.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/uevent.c
+++ b/common/uevent.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/common/uevent.h
+++ b/common/uevent.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/utest.c
+++ b/common/utest.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "utest.h"

--- a/common/utest.h
+++ b/common/utest.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define __android_log_write utest___android_log_write

--- a/common/uuid.c
+++ b/common/uuid.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <inttypes.h>

--- a/common/uuid.h
+++ b/common/uuid.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/common/verity.c
+++ b/common/verity.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/common/verity.h
+++ b/common/verity.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef VERITY_H

--- a/control/Android.mk
+++ b/control/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/control/Makefile
+++ b/control/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2018 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 CC ?= gcc
 DEVELOPMENT_BUILD ?= y

--- a/control/Makefile_lsb
+++ b/control/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 include Makefile

--- a/control/control.c
+++ b/control/control.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef ANDROID

--- a/converter/Android.mk
+++ b/converter/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/converter/Makefile
+++ b/converter/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 

--- a/converter/control.c
+++ b/converter/control.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef ANDROID

--- a/converter/control.h
+++ b/converter/control.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef CONTROL_H

--- a/converter/converter.c
+++ b/converter/converter.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef ANDROID

--- a/converter/docker.c
+++ b/converter/docker.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "docker.h"

--- a/converter/docker.h
+++ b/converter/docker.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef DOCKER_H

--- a/converter/util.c
+++ b/converter/util.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "util.h"

--- a/converter/util.h
+++ b/converter/util.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef UTIL_H

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 CC ?= gcc

--- a/daemon/Makefile_lsb
+++ b/daemon/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 include Makefile

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef _GNU_SOURCE

--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef AUDIT_H

--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef _GNU_SOURCE

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define MOD_NAME "c_cap"

--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/c_fifo.c
+++ b/daemon/c_fifo.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/c_net.test.c
+++ b/daemon/c_net.test.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/c_run.c
+++ b/daemon/c_run.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define MOD_NAME "c_run"

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/c_service.proto
+++ b/daemon/c_service.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/c_shiftid.c
+++ b/daemon/c_shiftid.c
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/daemon/c_smartcard.c
+++ b/daemon/c_smartcard.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define MOD_NAME "c_smartcard"

--- a/daemon/c_time.c
+++ b/daemon/c_time.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /*

--- a/daemon/c_uevent.c
+++ b/daemon/c_uevent.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/cc_mode/container.proto
+++ b/daemon/cc_mode/container.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/cc_mode/control.proto
+++ b/daemon/cc_mode/control.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/cc_mode/device.proto
+++ b/daemon/cc_mode/device.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/cc_mode/guestos.proto
+++ b/daemon/cc_mode/guestos.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef DEBUG_BUILD

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/cmld.stub.c
+++ b/daemon/cmld.stub.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "cmld.stub.h"

--- a/daemon/cmld.stub.h
+++ b/daemon/cmld.stub.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/compartment.c
+++ b/daemon/compartment.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/daemon/compartment.h
+++ b/daemon/compartment.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "container.h"

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/container.stub.c
+++ b/daemon/container.stub.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "container.stub.h"

--- a/daemon/container.stub.h
+++ b/daemon/container.stub.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/container.test.c
+++ b/daemon/container.test.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "container.h"

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/container_module.h
+++ b/daemon/container_module.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "control.h"

--- a/daemon/control.h
+++ b/daemon/control.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/control.srv.c
+++ b/daemon/control.srv.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "control.c"

--- a/daemon/control.test.c
+++ b/daemon/control.test.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "control.c"

--- a/daemon/crypto.c
+++ b/daemon/crypto.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "scd.pb-c.h"

--- a/daemon/crypto.h
+++ b/daemon/crypto.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef CRYPTO_H

--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "device_config.h"

--- a/daemon/device_config.h
+++ b/daemon/device_config.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/download.c
+++ b/daemon/download.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "download.h"

--- a/daemon/download.h
+++ b/daemon/download.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef DOWNLOAD_H

--- a/daemon/guestos.c
+++ b/daemon/guestos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "guestos.h"

--- a/daemon/guestos.h
+++ b/daemon/guestos.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef GUESTOS_H

--- a/daemon/guestos.proto
+++ b/daemon/guestos.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/guestos.stub.c
+++ b/daemon/guestos.stub.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "guestos.stub.h"

--- a/daemon/guestos.stub.h
+++ b/daemon/guestos.stub.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/guestos_config.c
+++ b/daemon/guestos_config.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "guestos_config.h"

--- a/daemon/guestos_config.h
+++ b/daemon/guestos_config.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef GUESTOS_CONFIG_H

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "guestos_mgr.h"

--- a/daemon/guestos_mgr.h
+++ b/daemon/guestos_mgr.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef GUESTOS_MGR_H

--- a/daemon/hardware.h
+++ b/daemon/hardware.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/hardware.stub.c
+++ b/daemon/hardware.stub.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "hardware.h"

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/daemon/hotplug.h
+++ b/daemon/hotplug.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2022 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/hw_arm.c
+++ b/daemon/hw_arm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/hw_ppc.c
+++ b/daemon/hw_ppc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/hw_x86.c
+++ b/daemon/hw_x86.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/input.c
+++ b/daemon/input.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdbool.h>

--- a/daemon/input.h
+++ b/daemon/input.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/ksm.c
+++ b/daemon/ksm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "ksm.h"

--- a/daemon/ksm.h
+++ b/daemon/ksm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef KSM_H

--- a/daemon/lxcfs.c
+++ b/daemon/lxcfs.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "lxcfs.h"

--- a/daemon/lxcfs.h
+++ b/daemon/lxcfs.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdbool.h>

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/daemon/mount.c
+++ b/daemon/mount.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #define _GNU_SOURCE

--- a/daemon/mount.h
+++ b/daemon/mount.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef MOUNT_H

--- a/daemon/scd.c
+++ b/daemon/scd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "scd.h"

--- a/daemon/scd.h
+++ b/daemon/scd.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef CML_SCD_H

--- a/daemon/scd.proto
+++ b/daemon/scd.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/daemon/time.c
+++ b/daemon/time.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "time.h"

--- a/daemon/time.h
+++ b/daemon/time.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <time.h>

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "tss.h"

--- a/daemon/tss.h
+++ b/daemon/tss.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef TSS_H

--- a/rattestation/Makefile
+++ b/rattestation/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2019 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 

--- a/rattestation/attestation.c
+++ b/rattestation/attestation.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdio.h>

--- a/rattestation/config.c
+++ b/rattestation/config.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdint.h>

--- a/rattestation/config.h
+++ b/rattestation/config.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef RATTESTATION_CONFIG_H_

--- a/rattestation/config.proto
+++ b/rattestation/config.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/rattestation/container_verify.c
+++ b/rattestation/container_verify.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "attestation.pb-c.h"

--- a/rattestation/container_verify.h
+++ b/rattestation/container_verify.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef CONTAINER_VERIFY_H_

--- a/rattestation/hash.c
+++ b/rattestation/hash.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdint.h>

--- a/rattestation/hash.h
+++ b/rattestation/hash.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef HASH_ALGO_H_

--- a/rattestation/ima_verify.h
+++ b/rattestation/ima_verify.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2021 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef IMA_VERIFY_H_

--- a/rattestation/main.c
+++ b/rattestation/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "common/macro.h"

--- a/rattestation/modsig.c
+++ b/rattestation/modsig.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include <stdio.h>

--- a/rattestation/modsig.h
+++ b/rattestation/modsig.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef MODSIG_H_

--- a/scd/Android.mk
+++ b/scd/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/scd/Makefile
+++ b/scd/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2018 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 CC ?= gcc

--- a/scd/Makefile_lsb
+++ b/scd/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 include Makefile

--- a/scd/control.c
+++ b/scd/control.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "control.h"

--- a/scd/control.h
+++ b/scd/control.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef SCD_CONTROL_H

--- a/scd/keyrewrap.c
+++ b/scd/keyrewrap.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "common/macro.h"

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "scd.h"

--- a/scd/scd.h
+++ b/scd/scd.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef SCD_H

--- a/scd/scd_shared.h
+++ b/scd/scd_shared.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef SCD_SHARED_H

--- a/scd/softtoken.c
+++ b/scd/softtoken.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "softtoken.h"

--- a/scd/softtoken.h
+++ b/scd/softtoken.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef SOFTTOKEN_H

--- a/scd/token.c
+++ b/scd/token.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "token.h"

--- a/scd/token.h
+++ b/scd/token.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef TOKEN_H

--- a/scd/tokencontrol.proto
+++ b/scd/tokencontrol.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
  syntax = "proto2";

--- a/scd/usbtoken.c
+++ b/scd/usbtoken.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 #include "token.h"
 #include "usbtoken.h"

--- a/scd/usbtoken.h
+++ b/scd/usbtoken.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef USBTOKEN_H

--- a/scripts/ci/VM-container-tests.sh
+++ b/scripts/ci/VM-container-tests.sh
@@ -350,7 +350,7 @@ while [[ $# > 0 ]]; do
       echo "-k, --kill                  Kill the VM after the tests are completed"
       echo "-n, --name        	Use the given name for the QEMU VM"
       echo "-p, --pki         	Use the given test PKI directory"
-      echo "-i, --image       	Test the given trust|me image instead of looking inside --dir"
+      echo "-i, --image       	Test the given GyroidOS image instead of looking inside --dir"
       echo "-m, --mode        	Test \"dev\", \"production\", or \"ccmode\" image? Default is \"dev\""
       echo "-e, --enable-schsm	Test with given schsm"
       echo "-k, --skip-rootca	Skip attempt to copy custom root CA to image"

--- a/service/Android.mk
+++ b/service/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/service/Makefile
+++ b/service/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 

--- a/service/Makefile_lsb
+++ b/service/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 include Makefile

--- a/service/exec_cap_systime.c
+++ b/service/exec_cap_systime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef ANDROID

--- a/service/service.c
+++ b/service/service.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef ANDROID

--- a/tpm2_control/Android.mk
+++ b/tpm2_control/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/tpm2_control/Makefile
+++ b/tpm2_control/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2018 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 CC ?= gcc

--- a/tpm2_control/Makefile_lsb
+++ b/tpm2_control/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2021 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 include Makefile

--- a/tpm2_control/tpm2d_control.c
+++ b/tpm2_control/tpm2d_control.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifdef ANDROID

--- a/tpm2d/Android.mk
+++ b/tpm2d/Android.mk
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2017 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 LOCAL_PATH:= $(call my-dir)

--- a/tpm2d/Makefile
+++ b/tpm2d/Makefile
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2018 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 CC ?= gcc

--- a/tpm2d/Makefile_lsb
+++ b/tpm2d/Makefile_lsb
@@ -1,5 +1,5 @@
 #
-# This file is part of trust|me
+# This file is part of GyroidOS
 # Copyright(c) 2013 - 2021 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
@@ -18,7 +18,7 @@
 # the file called "COPYING".
 #
 # Contact Information:
-# Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+# Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
 #
 
 include Makefile

--- a/tpm2d/attestation.proto
+++ b/tpm2d/attestation.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/tpm2d/control.c
+++ b/tpm2d/control.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "control.h"

--- a/tpm2d/control.h
+++ b/tpm2d/control.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/tpm2d/ml.c
+++ b/tpm2d/ml.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "attestation.pb-c.h"

--- a/tpm2d/ml.h
+++ b/tpm2d/ml.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef ML_H

--- a/tpm2d/nvmcrypt.c
+++ b/tpm2d/nvmcrypt.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 // for gnu version of basename

--- a/tpm2d/nvmcrypt.h
+++ b/tpm2d/nvmcrypt.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2018 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/tpm2d/rcontrol.c
+++ b/tpm2d/rcontrol.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 // #define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 

--- a/tpm2d/rcontrol.h
+++ b/tpm2d/rcontrol.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 /**

--- a/tpm2d/tpm2_commands.c
+++ b/tpm2d/tpm2_commands.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "tpm2d.h"

--- a/tpm2d/tpm2d.c
+++ b/tpm2d/tpm2d.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #include "tpm2d.h"

--- a/tpm2d/tpm2d.h
+++ b/tpm2d/tpm2d.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2017 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef TPM2D_H

--- a/tpm2d/tpm2d.proto
+++ b/tpm2d/tpm2d.proto
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 syntax = "proto2";

--- a/tpm2d/tpm2d_shared.h
+++ b/tpm2d/tpm2d_shared.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of trust|me
+ * This file is part of GyroidOS
  * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
@@ -18,7 +18,7 @@
  * the file called "COPYING".
  *
  * Contact Information:
- * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
 #ifndef TPM2D_SHARED_H


### PR DESCRIPTION
In source headers still project name trust|me was used which we changed to GyroidOS now. Further, contact information is updated to gyroidos@aisec.fraunhofer.de.