### PR TITLE
common/Makfile: Call ar via variable

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -23,6 +23,7 @@
 
 
 CC ?= gcc
+AR ?= ar
 DEVELOPMENT_BUILD ?= y
 AGGRESSIVE_WARNINGS ?= y
 SANITIZERS ?= n
@@ -94,13 +95,13 @@ OBJS_COMMON_EXT := \
 	uuid.o
 
 libcommon: $(OBJS_COMMON)
-	ar rcs libcommon.a $^
+	$(AR) rcs libcommon.a $^
 
 libcommon_full: $(OBJS_COMMON_FULL)
-	ar rcs libcommon_full.a $^
+	$(AR) rcs libcommon_full.a $^
 
 libcommon_ext: $(OBJS_COMMON_EXT)
-	ar rcs libcommon_ext.a $^
+	$(AR) rcs libcommon_ext.a $^
 
 %.o: %.c
 	$(CC) -c $(LOCAL_CFLAGS) $< -o $@


### PR DESCRIPTION
This commit changes the Makefile of libcommon
such that th ar tool specified by the build environment is used.
This is needed in Yocto builds, for example, as Yocto specifies the toolchain
to be used for a particular build.