### PR TITLE
Jenkinsfile: use env.CHANGE_TARGET instead of CHANGE_TARGET

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,11 +71,11 @@ pipeline {
 				script {
 					REPO_NAME = determineRepoName()
 
-					if (CHANGE_TARGET != null) {
+					if (env.CHANGE_TARGET != null) {
 						// in case this is a PR build
 						// set the BASE_BRANCH to the target
 						// e.g. PR-123 -> kirkstone
-						BASE_BRANCH = CHANGE_TARGET
+						BASE_BRANCH = env.CHANGE_TARGET
 					} else {
 						// in case this is a regular build
 						// let the BASE_BRANCH equal this branch


### PR DESCRIPTION
In case of non-PR build, CHNAGE_TARGET is not set. The variable does not exists at all, thus look in env.CHANGE_TARGET instead.