### PR TITLE
daemon/c_vol: Allow to start without dm-verity support

### DIFF
--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -669,7 +669,7 @@ c_vol_mount_image(c_vol_t *vol, const char *root, const mount_entry_t *mntent)
 	bool encrypted = mount_entry_is_encrypted(mntent);
 	bool overlay = false;
 	bool shiftids = false;
-	bool verity = false;
+	bool verity = mount_entry_get_verity_sha256(mntent) != NULL;
 	bool is_root = strcmp(mount_entry_get_dir(mntent), "/") == 0;
 	bool setup_mode = container_has_setup_mode(vol->container);
 


### PR DESCRIPTION
This will provide an update path from previous installations with GuestOSes which do not have a dm-verity hash image and root hash in its configuration file. Thus, it is possible to update the CML to its new version and the GuestOS could be updated later on independently.

Previous behavior: If we update the CML and do not switch to the new CML version in runtime, the older cmld will fail to import the new GuestOS configuration due to missing protobuf definitions. However, if we update the CML and do a reboot to get the new version running the c0 with its old GuestOS config wont start anymore.

The later is now possible with this patch. Thus, the old c0 gets up and running to provide the interface for the GuestOS update with new configuration options containing verity information.