### PR TITLE
Provide device stats through control interface

### DIFF
--- a/common/file.h
+++ b/common/file.h
@@ -170,4 +170,40 @@ file_touch(const char *file);
 void
 file_syncfs(const char *file);
 
+/**
+ * Check whether to files/dirs are on the same file system
+ * @param path1 path to first file or directory
+ * @param path2 path to second file or directory
+ * @return true if on same fs, false otherwise.
+ */
+bool
+file_on_same_fs(const char *path1, const char *path2);
+
+/**
+ * get disk space of underlying file system of the corresponding
+ * file or directory at path.
+ * @param path The file name or directory name
+ * @return The size of the file system on the given path or -1 on error.
+ */
+off_t
+file_disk_space(const char *path);
+
+/**
+ * get free disk space of underlying file system of the corresponding
+ * file or directory at path.
+ * @param path The file name or directory name
+ * @return The free space in the file system for the given path or -1 on error.
+ */
+off_t
+file_disk_space_free(const char *path);
+
+/**
+ * get free used disk space of underlying file system of the corresponding
+ * file or directory at path.
+ * @param path The file name or directory name
+ * @return The used disk space of the file system for the given path or -1 on error.
+ */
+off_t
+file_disk_space_used(const char *path);
+
 #endif /* FILE_H */

--- a/common/proc.h
+++ b/common/proc.h
@@ -86,4 +86,44 @@ proc_stat_btime(unsigned long long *boottime_sec);
 char *
 proc_get_cgroups_path_new(pid_t pid);
 
+typedef struct proc_meminfo proc_meminfo_t;
+
+/**
+ * Parses /proc/meminfo into an internal struct
+ * @return pointer to the newly allocated struct, NULL on error
+ */
+proc_meminfo_t *
+proc_meminfo_new();
+
+/**
+ * Frees the meminfo internal struct
+ * @param meminfo pointer to struct which should be freed
+ */
+void
+proc_meminfo_free(proc_meminfo_t *meminfo);
+
+/**
+ * Returns the mem_total in bytes retrieved from /proc/meminfo
+ * @param meminfo struct containing the parsed output of /proc/meminfo
+ * @return mem_total in bytes on success, -1 on error
+ */
+ssize_t
+proc_get_mem_total(const proc_meminfo_t *meminfo);
+
+/**
+ * Returns the mem_free in bytes retrieved from /proc/meminfo
+ * @param meminfo struct containing the parsed output of /proc/meminfo
+ * @return mem_total in bytes on success, -1 on error
+ */
+ssize_t
+proc_get_mem_free(const proc_meminfo_t *meminfo);
+
+/**
+ * Returns the mem_available in bytes retrieved from /proc/meminfo
+ * @param meminfo struct containing the parsed output of /proc/meminfo
+ * @return mem_total in bytes on success, -1 on error
+ */
+ssize_t
+proc_get_mem_available(const proc_meminfo_t *meminfo);
+
 #endif /* PROC_H */

--- a/control/control.c
+++ b/control/control.c
@@ -75,6 +75,8 @@ print_usage(const char *cmd)
 	       "        Sets the device to provisioned state which limits certain commands\n\n");
 	printf("   get_provisioned\n"
 	       "        Gets the device provisioned state.\n\n");
+	printf("   device_stats\n"
+	       "        Gets the device statistics about memory and disk usage.\n\n");
 	printf("   create <container.conf> [<container.sig> <container.cert>]\n"
 	       "        Creates a container from the given config file,\n"
 	       "        and optionally signature and certificate files\n\n");
@@ -357,6 +359,10 @@ main(int argc, char *argv[])
 	}
 	if (!strcasecmp(command, "get_provisioned")) {
 		msg.command = CONTROLLER_TO_DAEMON__COMMAND__GET_PROVISIONED;
+		goto send_message;
+	}
+	if (!strcasecmp(command, "device_stats")) {
+		msg.command = CONTROLLER_TO_DAEMON__COMMAND__GET_DEVICE_STATS;
 		goto send_message;
 	}
 	if (!strcasecmp(command, "push_guestos_config")) {

--- a/daemon/cc_mode/control.proto
+++ b/daemon/cc_mode/control.proto
@@ -65,6 +65,9 @@ message ControllerToDaemon {
 		// Also fills [container_uuids] with the corresponding container UUIDs.
 		GET_CONTAINER_CONFIG = 4;	// [container_uuid] -> [container_config]
 
+		// Retrive device statistics about mem and storage
+		GET_DEVICE_STATS = 6;
+
 		/**********************************************************************
 		 * @exclude
 		 * Commands (global) that modify the system 
@@ -103,7 +106,7 @@ message ControllerToDaemon {
 		 * Commands that operate on a specific container
 		**********************************************************************/
 
-	// The UUID of the container must be in the container_uuids field.
+		// The UUID of the container must be in the container_uuids field.
 
 		// Starts a container. Also needs [start_params].
 		CONTAINER_START = 101;
@@ -138,7 +141,7 @@ message ControllerToDaemon {
 	optional bytes container_config_signature = 18;		// signature of the container config file
 	optional bytes container_config_certificate = 19;	// sw signing certificate to verify the signature on the container config file
 	optional string newpin = 20;	// new pin for token  for CONTAINER_CHANGE_TOKEN_PIN
-	
+
 	// Daemon
 	optional bytes guestos_config_file = 30;	// new/updated GuestOS config for PUSH_GUESTOS_CONFIG
 	optional bytes guestos_config_signature = 31;	// signature of the GuestOS config file
@@ -159,6 +162,18 @@ message ContainerStartParams {
 message AssignInterfaceParams {
 	optional string iface_name = 1;
 	optional bool persistent = 2 [default = false];
+}
+
+message DeviceStats {
+	required uint64 disk_system = 1;
+	required uint64 disk_system_free = 2;
+	required uint64 disk_system_used = 3;
+	optional uint64 disk_containers = 4;
+	optional uint64 disk_containers_free = 5;
+	optional uint64 disk_containers_used = 6;
+	optional uint64 mem_total = 7;
+	optional uint64 mem_free = 8;
+	optional uint64 mem_available = 9;
 }
 
 /******************************************************************************
@@ -187,6 +202,8 @@ message DaemonToController {
 		CONTAINER_CMLD_HANDLES_PIN = 7; // -> [container_cmld_handles_pin]
 
 		RESPONSE = 13;			// -> [response]
+
+		DEVICE_STATS = 30;		// -> [device_stats]
 
 		DEVICE_CSR = 40;		// -> [device_csr]
 
@@ -234,6 +251,9 @@ message DaemonToController {
 	optional bool container_cmld_handles_pin = 11; 		// Indicate that CMLD handles pin input for container start and stop
 
 	optional Response response = 13;
+
+	optional DeviceStats device_stats = 20;		// device_stats for GET_DEVICE_STATS
+
 	optional bytes device_csr = 40;			// device_csr for DEVICE_CSR (provisioning)
 	optional bool device_is_provisioned = 41;	// device provisioned state (provisioning)
 }

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1913,3 +1913,9 @@ cmld_container_remove_net_iface(container_t *container, const char *iface, bool 
 	container_config_free(conf);
 	return 0;
 }
+
+const char *
+cmld_get_cmld_dir(void)
+{
+	return cmld_path;
+}

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -347,4 +347,10 @@ cmld_container_add_net_iface(container_t *container, container_pnet_cfg_t *pnet_
 int
 cmld_container_remove_net_iface(container_t *container, const char *iface, bool persistent);
 
+/**
+ * Returns the runtime path for cml's persistent data
+ */
+const char *
+cmld_get_cmld_dir(void);
+
 #endif /* CMLD_H */

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -798,15 +798,19 @@ control_check_command(control_t *control, const ControllerToDaemon *msg)
 		return true;
 	}
 	// Device is in privileged provisioned mode, only allow subset of commands
-	if ((msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_CONTAINERS) ||
+	if ((msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_GUESTOS_CONFIGS) ||
+	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_CONTAINERS) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CHANGE_TOKEN_PIN) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CREATE_CONTAINER) ||
+	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__REBOOT_DEVICE) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_PROVISIONED) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_START) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_UPDATE_CONFIG) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_STATUS) ||
+	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_CONFIG) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CMLD_HANDLES_PIN) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_STOP) ||
+	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_LIST_IFACES) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__PUSH_GUESTOS_CONFIG)) {
 		TRACE("Received command %d is valid in provisioned mode", msg->command);
 		return true;

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -76,6 +76,9 @@ message ControllerToDaemon {
 		//Returns logfiles stored in LOGFILE_DIR
 		GET_LAST_LOG = 5;
 
+		// Retrive device statistics about mem and storage
+		GET_DEVICE_STATS = 6;
+
 		//////////////////////////////////////////////
 		// Commands (global) that modify the system //
 		//////////////////////////////////////////////
@@ -211,6 +214,18 @@ message ControllerToDaemon {
 // Outgoing messages //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+message DeviceStats {
+	required uint64 disk_system = 1;
+	required uint64 disk_system_free = 2;
+	required uint64 disk_system_used = 3;
+	optional uint64 disk_containers = 4;
+	optional uint64 disk_containers_free = 5;
+	optional uint64 disk_containers_used = 6;
+	optional uint64 mem_total = 7;
+	optional uint64 mem_free = 8;
+	optional uint64 mem_available = 9;
+}
+
 /**
  * Control message sent from the cml-daemon on the device to the backend/cmdline tool/etc.
  */
@@ -238,6 +253,8 @@ message DaemonToController {
 		EXEC_END = 14;
 
 		EXEC_OUTPUT = 15;
+
+		DEVICE_STATS = 30;		// -> [device_stats]
 
 		DEVICE_CSR = 40;		// -> [device_csr]
 
@@ -294,6 +311,9 @@ message DaemonToController {
 	optional LogMessage log_message = 12;				// log message received because of OBSERVE_LOG_START
 
 	optional Response response = 13;
+
+	optional DeviceStats device_stats = 20;		// device_stats for GET_DEVICE_STATS
+
 	optional bytes device_csr = 40;			// device_csr for DEVICE_CSR (provisioning)
 	optional bool device_is_provisioned = 41;	// device provisioned state (provisioning)
 

--- a/service/service.c
+++ b/service/service.c
@@ -178,9 +178,8 @@ process_audit_record(CmldToServiceMessage *msg, uint8_t *buf, uint32_t buf_len)
 
 	int ret = -1;
 
-	char tmpfile[17] = "/tmp/audit_XXXXXX";
-
-	if (!strcmp("", mktemp(tmpfile))) {
+	char tmpfile[] = "/tmp/audit_XXXXXX";
+	if (-1 == mkstemp(tmpfile)) {
 		ERROR_ERRNO("Failed to generate temporary filename");
 		return -1;
 	}


### PR DESCRIPTION
Main commit of this feature: 

    daemon/control: Provide device stats through control interface
    
    Introduce a new protobuf message command DEVICE_STATS to retrieve
    statistics about memory and disk utilization of the CML.
    This could be used in c0 to monitor if container space may run out or
    system disk is getting full due to any reasons.
