### PR TITLE
Fixes related to token handling

### DIFF
--- a/scd/Makefile
+++ b/scd/Makefile
@@ -31,6 +31,9 @@ TRUSTME_SCHSM ?= n
 LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -pedantic -O2
 LOCAL_CFLAGS += -DTPM_POSIX
 LOCAL_CFLAGS += -Wall -Wextra -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
+
+LOCAL_LFLAGS := -lc -lprotobuf-c -lprotobuf-c-text -lssl -lcrypto -Lcommon -lcommon
+
 ifeq ($(WCAST_ALIGN),y)
     LOCAL_CFLAGS += -Wcast-align
 endif
@@ -56,7 +59,8 @@ ifeq ($(SANITIZERS),y)
 endif
 ifeq ($(TRUSTME_SCHSM), y)
     # If requested, we build sc-hsm support into trustme
-    LOCAL_CFLAGS += -DENABLESCHSM -lctccid
+    LOCAL_CFLAGS += -DENABLESCHSM
+	LOCAL_LFLAGS += -lctccid
     SRC_FILES += \
 	sc-hsm-lib/sc-hsm-cardservice.c \
 	usbtoken.c
@@ -109,7 +113,7 @@ libcommon:
 	$(MAKE) -C common libcommon
 
 scd: libcommon $(SRC_FILES)
-	$(CC) $(LOCAL_CFLAGS) $(SRC_FILES) -lc -lprotobuf-c -lprotobuf-c-text -lssl -lcrypto -Lcommon -lcommon -o scd
+	$(CC) $(LOCAL_CFLAGS) $(SRC_FILES) $(LOCAL_LFLAGS) -o scd
 
 
 .PHONY: clean

--- a/scd/token.c
+++ b/scd/token.c
@@ -39,6 +39,9 @@
 
 #define SCD_TOKENCONTROL_SOCK_LISTEN_BACKLOG 1
 
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
 typedef struct scd_tokencontrol {
 	int cfd;
 	int lsock;
@@ -244,6 +247,9 @@ scd_tokencontrol_cb_accept(int fd, unsigned events, UNUSED event_io_t *io, void 
 		DEBUG("Made tokenctrl_cfd non-blocking");
 
 		// only accept one connection per socket at a time
+		token->token_data->tctrl->events =
+			list_remove(token->token_data->tctrl->events, io);
+
 		wrapped_remove_event_io(io);
 
 		event_io_t *event = event_io_new(token->token_data->tctrl->cfd, EVENT_IO_READ,
@@ -253,7 +259,6 @@ scd_tokencontrol_cb_accept(int fd, unsigned events, UNUSED event_io_t *io, void 
 			list_append(token->token_data->tctrl->events, event);
 
 		event_add_io(event);
-
 	} else if (events & EVENT_IO_EXCEPT) {
 		TRACE("EVENT_IO_EXCEPT on socket %d, closing...", fd);
 	} else {


### PR DESCRIPTION
This PR adds fixes for handling of USB tokens by the CML:
- scd/token.c: Properly unlink event accepting incoming connections  from the scd's internal list
- daemon/hotplug.c: Wait for device node to become available before sending TOKEN_ADD request
- Properly handle linker flags in scd/Makefile