### PR TITLE
Fix logfile retrieval for large logfiles

### DIFF
--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -35,8 +35,6 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 
-#define PROTOBUF_MAX_MESSAGE_SIZE 1024 * 1024
-
 // TODO update naming scheme
 
 uint32_t

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -37,6 +37,9 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+#define PROTOBUF_MAX_MESSAGE_SIZE 1024 * 1024
+#define PROTOBUF_MAX_OVERHEAD 1024
+
 /**
  * Packs the given protobuf message struct
  * and returns it's binary serialized form.

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -232,7 +232,7 @@ message DeviceStats {
 message DaemonToController {
 	reserved 10; // legacy
 	enum Code {
-		reserved 6, 10, 11; // legacy
+		reserved 6, 10; // legacy
 		// Push info to other endpoint:
 
 		GUESTOS_CONFIGS_LIST = 1;	// -> [guestos_config]
@@ -246,7 +246,9 @@ message DaemonToController {
 
 		CONTAINER_CMLD_HANDLES_PIN = 7; // -> [container_cmld_handles_pin]
 
-		LOG_MESSAGE = 12;		// -> [log_message]
+		LOG_MESSAGE_FRAGMENT = 11;		// -> [log_message]
+
+		LOG_MESSAGE_FINAL = 12;		// -> [log_message]
 
 		RESPONSE = 13;			// -> [response]
 

--- a/daemon/lxcfs.c
+++ b/daemon/lxcfs.c
@@ -47,6 +47,8 @@ static const char *
 lxcfs_get_bin_path_if_supported(void)
 {
 	char *fses = file_read_new(PROC_FSES, 2048);
+	IF_NULL_RETVAL(fses, NULL);
+
 	bool ret = strstr(fses, "fuse") ? true : false;
 
 	mem_free0(fses);

--- a/scripts/ci/VM-container-commands.sh
+++ b/scripts/ci/VM-container-commands.sh
@@ -209,7 +209,7 @@ cmd_control_get_guestos_version(){
 }
 
 cmd_control_retrieve_logs() {
-	do_test_cmd_output "/usr/sbin/control retrieve_logs $1" "response: CMD_OK"
+	do_test_cmd_output "/usr/sbin/control retrieve_logs $1" "$2"
 }
 
 cmd_control_get_provisioned() {
@@ -218,4 +218,16 @@ cmd_control_get_provisioned() {
 
 cmd_control_set_provisioned() {
 	do_test_cmd_output "/usr/sbin/control set_provisioned" "response: $1"
+}
+
+cmd_control_list_guestos_silent() {
+    OUTPUT="$(ssh ${SSH_OPTS} "/usr/sbin/control list_guestos" 2>&1)" || true
+    dbg "Command returned $OUTPUT, code: $?"
+
+    if ! echo "$OUTPUT" | grep -q "$1";then
+        dbg "exitcode: $?"
+        echo "ERROR: Check failed, expected \"$2\", got:"
+        echo "\"$OUTPUT\""
+        exit 1
+    fi 
 }

--- a/scripts/ci/VM-container-tests.sh
+++ b/scripts/ci/VM-container-tests.sh
@@ -308,6 +308,23 @@ do_test_complete() {
 
 #	# Remove test container if in second VM run
 	if [[ "$1" == "second_run" ]];then
+		TMPDIR="$(ssh ${SSH_OPTS} "mktemp -d -p /tmp")"
+		ssh ${SSH_OPTS} "sync && sleep 2"
+
+		if [[ "ccmode" == "${MODE}" ]];then
+			cmd_control_retrieve_logs "${TMPDIR}" "CMD_UNSUPPORTED"
+		else
+			for I in {1..1200};do
+				cmd_control_list_guestos_silent "trustx-coreos" 2>/dev/null 
+		
+				if [ 0 = "$(($I%100))" ];then
+					echo "list_guetos_silent: Completed $I commands";
+				fi
+			done
+	
+			cmd_control_retrieve_logs "${TMPDIR}" "CMD_OK"
+		fi
+
 		echo "Second test run, removing container"
 		cmd_control_remove "signedcontainer" "$TESTPW"
 


### PR DESCRIPTION
This PR adapts the implementation of GET_LAST_LOG to support large log files.
To this end, large log files are sent by fragments.