### PR TITLE
daemon: Introduce compartment flags for feature configuration

### DIFF
--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -555,7 +555,7 @@ c_cgroups_devices_init(c_cgroups_t *cgroups)
 	}
 
 	/* allow to run a KVM VMM inside an unprivileged Namespace */
-	if (container_get_type(cgroups->container) == COMPARTMENT_TYPE_KVM) {
+	if (container_get_type(cgroups->container) == CONTAINER_TYPE_KVM) {
 		if (c_cgroups_devices_allow(cgroups, "c 10:232 rwm") < 0)
 			return -1;
 		INFO("Allowing acces to /dev/kvm for lkvm inside new namespace");

--- a/daemon/c_cgroups_dev.c
+++ b/daemon/c_cgroups_dev.c
@@ -747,7 +747,7 @@ c_cgroups_dev_start_post_clone(void *cgroups_devp)
 	}
 
 	/* allow to run a KVM VMM inside an unprivileged Namespace */
-	if (container_get_type(cgroups_dev->container) == COMPARTMENT_TYPE_KVM) {
+	if (container_get_type(cgroups_dev->container) == CONTAINER_TYPE_KVM) {
 		if (c_cgroups_dev_allow(cgroups_dev, "c 10:232 rwm") < 0)
 			return -COMPARTMENT_ERROR_CGROUPS;
 		INFO("Allowing acces to /dev/kvm for lkvm inside new namespace");

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1755,7 +1755,7 @@ c_vol_start_child(void *volp)
 		goto error;
 	}
 
-	if (container_get_type(vol->container) == COMPARTMENT_TYPE_KVM)
+	if (container_get_type(vol->container) == CONTAINER_TYPE_KVM)
 		return 0;
 
 	INFO("Switching to new rootfs in '%s'", vol->root);

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -487,7 +487,7 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 	ns_usr = file_exists("/proc/self/ns/user") ? container_config_has_userns(conf) : false;
 	ns_net = container_config_has_netns(conf);
 
-	compartment_type_t type = container_config_get_type(conf);
+	container_type_t type = container_config_get_type(conf);
 
 	list_t *pnet_cfg_list = container_config_get_net_ifaces_list_new(conf);
 
@@ -1230,7 +1230,7 @@ cmld_init_c0(const char *path, const char *c0os)
 	char **init_argv = guestos_get_init_argv_new(c0_os);
 
 	container_t *new_c0 =
-		container_new(c0_uuid, "c0", COMPARTMENT_TYPE_CONTAINER, false, c0_ns_net, c0_os,
+		container_new(c0_uuid, "c0", CONTAINER_TYPE_CONTAINER, false, c0_ns_net, c0_os,
 			      NULL, c0_images_folder, c0_ram_limit, NULL, 0xffffff00, false,
 			      cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL, init,
 			      init_argv, NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false);

--- a/daemon/compartment.h
+++ b/daemon/compartment.h
@@ -62,15 +62,13 @@ typedef struct compartment_callback compartment_callback_t;
 typedef struct compartment_extension compartment_extension_t;
 
 /**
- * Represents the type of a compartment. Could be either
- * CONTAINER_TYPE_CONTAINER for a namspaced os-level virtualized
- * or CONTAINER_TYPE_KVM for a full virtulized execution of the
- * child's init process.
+ * FLAGS for configuring a compartment
  */
-typedef enum {
-	COMPARTMENT_TYPE_CONTAINER = 1,
-	COMPARTMENT_TYPE_KVM,
-} compartment_type_t;
+#define COMPARTMENT_FLAG_TYPE_CONTAINER 0x0000000000000001
+#define COMPARTMENT_FLAG_TYPE_KVM 0x0000000000000002
+#define COMPARTMENT_FLAG_NS_USER 0x0000000000000004
+#define COMPARTMENT_FLAG_NS_NET 0x0000000000000008
+#define COMPARTMENT_FLAG_NS_IPC 0x0000000000000010
 
 /**
  * Represents the current compartment state.
@@ -139,9 +137,9 @@ compartment_module_get_instance_by_name(const compartment_t *compartment, const 
  * @return The new compartment instance.
  */
 compartment_t *
-compartment_new(const uuid_t *uuid, const char *name, compartment_type_t type, bool ns_usr,
-		bool ns_net, const char *init, char **init_argv, char **init_env,
-		size_t init_env_len, const compartment_extension_t *extension);
+compartment_new(const uuid_t *uuid, const char *name, uint64_t flags, const char *init,
+		char **init_argv, char **init_env, size_t init_env_len,
+		const compartment_extension_t *extension);
 
 /**
  * Creates a new compartment_extension object,
@@ -368,10 +366,10 @@ compartment_state_t
 compartment_get_prev_state(const compartment_t *compartment);
 
 /**
- * Returns the the type of the compartment.
+ * Returns the the flags of the compartment.
  */
-compartment_type_t
-compartment_get_type(const compartment_t *compartment);
+uint64_t
+compartment_get_flags(const compartment_t *compartment);
 
 /**
  * Register a callback function which is always called when the compartment's
@@ -410,6 +408,9 @@ compartment_has_netns(const compartment_t *compartment);
 bool
 compartment_has_userns(const compartment_t *compartment);
 
+bool
+compartment_has_ipcns(const compartment_t *compartment);
+
 void
 compartment_set_setup_mode(compartment_t *compartment, bool setup);
 
@@ -435,8 +436,9 @@ compartment_uuid_is_c0id(const uuid_t *uuid);
 /**
  * Set directory for log output of compartment
  *
- * This function set a directory where a logfile for the stdout of the child process
- * of the compartment is logged. (only effective for COMPARTMENT_TYPE_KVM)
+ * This function set a directory where a logfile for the stdout of the
+ * child process of the compartment is logged. (only effective for
+ * compartments with COMPARTMENT_FLAG_TYPE_KVM)
  */
 void
 compartment_set_debug_log_dir(compartment_t *compartment, const char *dir);

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -62,6 +62,17 @@ typedef struct container container_t;
 typedef struct container_callback container_callback_t;
 
 /**
+ * Represents the type of a container. Could be either
+ * CONTAINER_TYPE_CONTAINER for a namspaced os-level virtualized
+ * or CONTAINER_TYPE_KVM for a full virtulized execution of the
+ * child's init process.
+ */
+typedef enum {
+	CONTAINER_TYPE_CONTAINER = 1,
+	CONTAINER_TYPE_KVM,
+} container_type_t;
+
+/**
  * Represents the type of token which the container is associated with.
  * The token is used to i.a. wrap the container's disk encryption key.
  */
@@ -120,8 +131,8 @@ enum container_smartcard_error {
  * @return The new container instance.
  */
 container_t *
-container_new(const uuid_t *uuid, const char *name, compartment_type_t type, bool ns_usr,
-	      bool ns_net, const void *os, const char *config_filename, const char *images_folder,
+container_new(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr, bool ns_net,
+	      const void *os, const char *config_filename, const char *images_folder,
 	      unsigned int ram_limit, const char *cpus_allowed, uint32_t color,
 	      bool allow_autostart, const char *dns_server, list_t *net_ifaces,
 	      char **allowed_devices, char **assigned_devices, list_t *vnet_cfg_list,
@@ -307,6 +318,12 @@ container_get_dev_allow_list(const container_t *container);
 const char **
 container_get_dev_assign_list(const container_t *container);
 
+/**
+ * Returns the the type of the container.
+ */
+container_type_t
+container_get_type(const container_t *container);
+
 // ##################################################################
 // compartment wrappers
 // ##################################################################
@@ -370,9 +387,6 @@ container_get_state(const container_t *container);
 
 compartment_state_t
 container_get_prev_state(const container_t *container);
-
-compartment_type_t
-container_get_type(const container_t *container);
 
 const char *
 container_get_key(const container_t *container);

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -57,14 +57,14 @@ struct container_config {
 /**
  * The usual identity map between two corresponding C and protobuf enums.
  */
-compartment_type_t
+container_type_t
 container_config_proto_to_type(ContainerType type)
 {
 	switch (type) {
 	case CONTAINER_TYPE__CONTAINER:
-		return COMPARTMENT_TYPE_CONTAINER;
+		return CONTAINER_TYPE_CONTAINER;
 	case CONTAINER_TYPE__KVM:
-		return COMPARTMENT_TYPE_KVM;
+		return CONTAINER_TYPE_KVM;
 	default:
 		FATAL("Unhandled value for ContainerType: %d", type);
 	}
@@ -685,10 +685,10 @@ container_config_get_color(UNUSED const container_config_t *config)
 	return 0;
 }
 
-compartment_type_t
+container_type_t
 container_config_get_type(UNUSED const container_config_t *config)
 {
-	return COMPARTMENT_TYPE_CONTAINER;
+	return CONTAINER_TYPE_CONTAINER;
 }
 
 bool
@@ -717,7 +717,7 @@ container_config_get_color(const container_config_t *config)
 	return config->cfg->color;
 }
 
-compartment_type_t
+container_type_t
 container_config_get_type(const container_config_t *config)
 {
 	ASSERT(config);

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -126,7 +126,7 @@ container_config_fill_mount(const container_config_t *config, mount_t *mnt);
 uint32_t
 container_config_get_color(const container_config_t *config);
 
-compartment_type_t
+container_type_t
 container_config_get_type(const container_config_t *config);
 
 uint64_t

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -201,15 +201,15 @@ control_compartment_state_to_proto(compartment_state_t state)
  * The usual identity map between two corresponding C and protobuf enums.
  */
 ContainerType
-control_compartment_type_to_proto(compartment_type_t type)
+control_container_type_to_proto(container_type_t type)
 {
 	switch (type) {
-	case COMPARTMENT_TYPE_CONTAINER:
+	case CONTAINER_TYPE_CONTAINER:
 		return CONTAINER_TYPE__CONTAINER;
-	case COMPARTMENT_TYPE_KVM:
+	case CONTAINER_TYPE_KVM:
 		return CONTAINER_TYPE__KVM;
 	default:
-		FATAL("Unhandled value for compartment_type_t: %d", type);
+		FATAL("Unhandled value for container_type_t: %d", type);
 	}
 }
 
@@ -227,7 +227,7 @@ control_container_status_new(const container_t *container)
 	container_status__init(c_status);
 	c_status->uuid = mem_strdup(uuid_string(container_get_uuid(container)));
 	c_status->name = mem_strdup(container_get_name(container));
-	c_status->type = control_compartment_type_to_proto(container_get_type(container));
+	c_status->type = control_container_type_to_proto(container_get_type(container));
 	c_status->state = control_compartment_state_to_proto(container_get_state(container));
 	c_status->uptime = container_get_uptime(container);
 	c_status->created = container_get_creation_time(container);

--- a/daemon/oci.c
+++ b/daemon/oci.c
@@ -490,7 +490,7 @@ oci_container_new(const char *store_path, const char *peer_path, const char *bun
 	ns_usr = file_exists("/proc/self/ns/user") ? true : false;
 	ns_net = true;
 
-	compartment_type_t type = COMPARTMENT_TYPE_CONTAINER;
+	container_type_t type = CONTAINER_TYPE_CONTAINER;
 
 	list_t *pnet_cfg_list = NULL;
 


### PR DESCRIPTION
Now the compartment type is hold as flag as well as the namespace configuration. The previous compartment_type_t is now specified as container_type_t to transparency map the existing container API. The compartment flags attribute is currently hidden in compartment_t and only exported to the higher level container module.