### PR TITLE
daemon/c_seccomp.c: Use only for x86

### DIFF
--- a/daemon/c_seccomp.c
+++ b/daemon/c_seccomp.c
@@ -37,6 +37,7 @@
 
 #include "compartment.h"
 #include "audit.h"
+#include "hardware.h"
 
 #include "common/macro.h"
 #include "common/mem.h"
@@ -568,6 +569,8 @@ static compartment_module_t c_seccomp_module = {
 static void INIT
 c_seccomp_init(void)
 {
+	//TODO: port to multiarch support
+	IF_FALSE_RETURN(0 == strcmp("x86", hardware_get_name()));
 	// register this module in compartment.c
 	compartment_register_module(&c_seccomp_module);
 }


### PR DESCRIPTION
Currently the seccomp code is only developed and tested for x86 and provably breaks the arm builds. Until the code is properly ported to arm we enable the module only for x86.