### PR TITLE
Fixes related to sanitizers and debugging logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
 pipeline {
 	agent any
 
+	options {
+		preserveStashes(buildCount: 1) 
+	}
+
 	parameters {
 		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
 	}

--- a/common/cryptfs.c
+++ b/common/cryptfs.c
@@ -404,11 +404,13 @@ create_device_node(const char *name)
 	char *device = cryptfs_get_device_path_new(name);
 	/* we might need to remove this device first */
 	unlink(device);
-	if (mknod(device, S_IFBLK | 00777, io->dev) != 0) {
+	if (mknod(device, S_IFBLK | 00777, io->dev) != 0 && errno != EEXIST) {
 		ERROR_ERRNO("Cannot mknod device %s", device);
 		mem_free0(buffer);
 		mem_free0(device);
 		return NULL;
+	} else if (errno == EEXIST) {
+		DEBUG("Device %s already exists, continuing", device);
 	}
 	mem_free0(buffer);
 	return device;

--- a/common/list.c
+++ b/common/list.c
@@ -78,9 +78,9 @@ list_delete(list_t *list)
 list_t *
 list_unlink(list_t *list, list_t *elem)
 {
-	IF_NULL_RETVAL(elem, list);
-	IF_FALSE_RETVAL(list_contains(list, elem),
-			list); // this also handles the case that list is NULL
+	IF_NULL_RETVAL_TRACE(elem, list);
+	IF_FALSE_RETVAL_TRACE(list_contains(list, elem),
+			      list); // this also handles the case that list is NULL
 
 	list_t *head = list;
 

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -270,7 +270,7 @@ protobuf_dump_message(int fd, const ProtobufCMessage *message)
 	ASSERT(message);
 
 	char *string;
-	size_t msg_len = protobuf_string_from_message(&string, (ProtobufCMessage *)message, NULL);
+	size_t msg_len = protobuf_string_from_message(&string, message, NULL);
 	if (NULL == string) {
 		WARN("Failed to serialize text protobuf message to string.");
 		return -1;
@@ -369,7 +369,7 @@ protobuf_message_new_from_buf(const uint8_t *buf, size_t buflen,
 }
 
 ssize_t
-protobuf_message_write_to_file(const char *filename, ProtobufCMessage *message)
+protobuf_message_write_to_file(const char *filename, const ProtobufCMessage *message)
 {
 	ASSERT(filename);
 	ASSERT(message);
@@ -391,7 +391,7 @@ protobuf_message_write_to_file(const char *filename, ProtobufCMessage *message)
 }
 
 size_t
-protobuf_string_from_message(char **buffer_proto_string, ProtobufCMessage *message,
+protobuf_string_from_message(char **buffer_proto_string, const ProtobufCMessage *message,
 			     ProtobufCAllocator *allocator)
 {
 	ASSERT(message);

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -175,7 +175,7 @@ protobuf_message_new_from_buf(const uint8_t *buf, size_t buflen,
  * @return          the length of the serialized message
  */
 ssize_t
-protobuf_message_write_to_file(const char *filename, ProtobufCMessage *message);
+protobuf_message_write_to_file(const char *filename, const ProtobufCMessage *message);
 
 /**
  * Wrapper function for the protobug_c_text_to_string function
@@ -184,7 +184,7 @@ protobuf_message_write_to_file(const char *filename, ProtobufCMessage *message);
  * @param allocator protobuf C allocator
 */
 size_t
-protobuf_string_from_message(char **buffer_proto_string, ProtobufCMessage *message,
+protobuf_string_from_message(char **buffer_proto_string, const ProtobufCMessage *message,
 			     ProtobufCAllocator *allocator);
 
 #endif // PROTOBUF_H

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -18,11 +18,6 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
 RUN update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-13 100
 RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
-#
-# protobuf-c-text library
-# https://github.com/protobuf-c/protobuf-c-text
-RUN cd /opt && git clone https://github.com/gyroidos/external_protobuf-c-text.git && cd /opt/external_protobuf-c-text && ./autogen.sh
-RUN cd /opt/external_protobuf-c-text && ./configure && make && make install
 
 # Image signing
 RUN apt-get update && apt-get install -y python3-protobuf
@@ -47,16 +42,6 @@ RUN apt-get update && apt-get install -y kmod procps curl
 
 RUN apt-get install -y apt-utils
 
-RUN apt-get install -y vim openjdk-17-jdk-headless ca-certificates-java
-
-
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
-	&& apt-get install -y nodejs
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-	&& apt-get update \
-	&& apt-get install yarn
-
 # optee python dependings
 RUN apt-get update && apt-get install -y python3-cryptography
 
@@ -69,7 +54,14 @@ ARG CML_BUILDER=jenkins
 
 LABEL "com.gyroidos.builder"="${lbl}"
 
-# set workdir
+# protobuf-c-text library
+ADD https://github.com/gyroidos/external_protobuf-c-text/archive/refs/heads/master.zip /opt/external_protobuf-c-text-master.zip
+
+RUN cd /opt && unzip external_protobuf-c-text-master.zip
+
+RUN cd /opt/external_protobuf-c-text-master && ./autogen.sh && ./configure && make && make install
+
+# Set workdir
 WORKDIR "/opt/ws-yocto/"
 
 #COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -64,6 +64,12 @@ RUN echo "deb http://ftp.de.debian.org/debian bullseye-backports main contrib no
 
 RUN apt-get -y update && apt-get -y install -t bullseye-backports linux-image-amd64
 
+# set image label
+ARG CML_BUILDER=jenkins
+
+LABEL "com.gyroidos.builder"="${lbl}"
+
+# set workdir
 WORKDIR "/opt/ws-yocto/"
 
 #COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
This PR adds a number of fixes to increase debuggability and readability of debugging logs:
- Make necessary adaption to enable compilation with sanitizers
- Set log level to TRACE for a number of log messages
- Add more detailed tracing to common/protobuf.c