### PR TITLE
Bugfix: Fix running out ouf inotify descriptors

### DIFF
--- a/common/dir.c
+++ b/common/dir.c
@@ -195,6 +195,8 @@ dir_copy_folder_contents_cb(const char *path, const char *name, void *data)
 	dir_copy_params_t *params = dir_copy_params_new(p->target, name, p->filter, p->data);
 	char *file_dst = params->target;
 
+	IF_NULL_GOTO_ERROR(file_dst, out);
+
 	TRACE("p->taget:%s params->target: %s", p->target, params->target);
 
 	// skip filtered files

--- a/common/event.c
+++ b/common/event.c
@@ -569,14 +569,26 @@ event_inotify_cb(int fd, unsigned events, UNUSED event_io_t *io, UNUSED void *da
 static int
 event_inotify_fd(void)
 {
-	if (event_inotify_io && event_inotify_io->fd >= 0)
+	if (event_inotify_io && event_inotify_io->fd >= 0) {
+		TRACE("Using existing event_inotify_io %p (fd=%d)", (void *)event_inotify_io,
+		      event_inotify_io->fd);
 		return event_inotify_io->fd;
+	}
 
 	int fd = inotify_init();
 	if (fd < 0)
 		FATAL_ERRNO("Could not init inotify");
 
 	event_io_t *io = event_io_new(fd, EVENT_IO_READ, &event_inotify_cb, NULL);
+
+	if (NULL == io) {
+		FATAL_ERRNO("Could not init event_inotify_io (fd=%d)", fd);
+	}
+
+	TRACE("Setting event_inotify_io=%p (fd=%d)", (void *)event_inotify_io,
+	      event_inotify_io->fd);
+
+	event_inotify_io = io;
 	event_add_io(io);
 
 	return fd;

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -262,6 +262,7 @@ c_idmapped_new(compartment_t *compartment)
 	c_idmapped_t *idmapped = mem_new0(c_idmapped_t, 1);
 	idmapped->container = compartment_get_extension_data(compartment);
 	idmapped->is_dev_mounted = false;
+	idmapped->src_index = 0;
 
 	TRACE("new c_idmapped struct was allocated");
 
@@ -837,6 +838,7 @@ c_idmapped_cleanup(void *idmappedp, UNUSED bool is_rebooting)
 	idmapped->mapped_mnts = NULL;
 
 	idmapped->is_dev_mounted = false;
+	idmapped->src_index = 0;
 }
 
 static compartment_module_t c_idmapped_module = {

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -28,8 +28,8 @@
 #include <fcntl.h>
 #include <linux/magic.h>
 #include <linux/types.h>
-#include <linux/mount.h>
 #include <sys/mount.h>
+#include <linux/mount.h>
 #include <sys/syscall.h>
 #include <sys/vfs.h>
 #include <unistd.h>


### PR DESCRIPTION
This commit initializes the global variable event_inotify_io so that the inotify descriptor is reused after being initialized the first time. If this variable is not correctly initialized, event_inotify_fd() will always create a new inotify descriptor (without properly closing prior ones) which leads to running into the process' inotify limit after a few container starts.