### PR TITLE
bugfixes: c_cgroups_v2 inotify handling, c_idmapped overlay handling

### DIFF
--- a/daemon/c_cgroups_v2.c
+++ b/daemon/c_cgroups_v2.c
@@ -617,6 +617,11 @@ c_cgroups_cleanup(void *cgroupsp, UNUSED bool is_rebooting)
 			     container_get_description(cgroups->container));
 		}
 	}
+
+	/* remove inotify events handling */
+	event_remove_inotify(cgroups->inotify_cgroup_events);
+	event_inotify_free(cgroups->inotify_cgroup_events);
+	cgroups->inotify_cgroup_events = NULL;
 }
 
 static compartment_module_t c_cgroups_module = {

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -385,9 +385,6 @@ c_idmapped_mount_ovl(const char *overlayfs_mount_dir, const char *target, const 
 	DEBUG("Mounting overlayfs: work_dir=%s, upper_dir=%s, lower_dir=%s, target dir=%s",
 	      work_dir, upper_dir, ovl_lower, target);
 
-	struct statfs ovl_statfs;
-	statfs(overlayfs_mount_dir, &ovl_statfs);
-
 	// needed for tmpfs of fallback mechanism where lower image is read only and a temporary
 	// upper tmpfs for chowning is used
 	if (dir_mkdir_p(upper_dir, 0777) < 0) {

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -513,7 +513,6 @@ c_idmapped_prepare_dir(c_idmapped_t *idmapped, struct c_idmapped_mnt *mnt, const
 				return -1;
 			}
 		}
-	} else {
 	}
 
 	mnt->src = mem_printf("%s/%s/src/%d", IDMAPPED_SRC_DIR,

--- a/daemon/c_uevent.c
+++ b/daemon/c_uevent.c
@@ -417,6 +417,19 @@ c_uevent_stop(void *ueventp)
 	return 0;
 }
 
+static void
+c_uevent_cleanup(void *ueventp, UNUSED bool rebooting)
+{
+	c_uevent_t *uevent = ueventp;
+	ASSERT(uevent);
+
+	char *mnt_media = mem_printf("%s/media", container_get_rootdir(uevent->container));
+	if (umount(mnt_media) < 0)
+		WARN_ERRNO("Could not umount %s", mnt_media);
+
+	mem_free0(mnt_media);
+}
+
 static compartment_module_t c_uevent_module = {
 	.name = MOD_NAME,
 	.compartment_new = c_uevent_new,
@@ -431,7 +444,7 @@ static compartment_module_t c_uevent_module = {
 	.start_child = NULL,
 	.start_pre_exec_child = NULL,
 	.stop = c_uevent_stop,
-	.cleanup = NULL,
+	.cleanup = c_uevent_cleanup,
 	.join_ns = NULL,
 };
 


### PR DESCRIPTION
**cgroups_v2**:
The inotify listener for the cgroup events file where never removed. Thus, causing a mem_leak and exhaustion of inotify fds on start stop cycle. We now properly cleanup the groups->inotify_cgroup_event in c_cgroups_cleanup().

**idmapped**:
To get the upper directory mapped correctly we need to add a mnt
struct as mapping for the corresponding image. Otherwise the upper
directory would just be created somewhere in the cml storage. This
was resulting in exhausting the ram since "persistent" data of the
containers where written to /tmp/ of the CML which is a tmpfs.