### PR TITLE
daemon/hotplug: fixed sysfs handling for device search

### DIFF
--- a/daemon/c_smartcard.c
+++ b/daemon/c_smartcard.c
@@ -1118,6 +1118,9 @@ c_smartcard_free(void *smartcardp)
 	/* release scd connection */
 	close(smartcard->sock);
 
+	if (smartcard->token_serial)
+		mem_free0(smartcard->token_serial);
+
 	mem_free0(smartcard);
 }
 


### PR DESCRIPTION
In hotplug_usbdev_sysfs_foreach_cb(), do not exit early without proper cleanup of memory buffers. Instead set the bool veariable 'found' correctly and use this to propererly return 0 or 1. Thus, dir_foreach() also can count the succeeded callbacks correctly.