### PR TITLE
Renamed static build of 'cml-service-container' to 'cml-service-container-static'

### DIFF
--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1819,11 +1819,11 @@ c_vol_start_child(void *volp)
 	char *cservice_dir_p = dirname(cservice_dir);
 	if (dir_mkdir_p(cservice_dir_p, 0755) < 0) {
 		WARN_ERRNO("Could not mkdir '%s' dir", cservice_dir_p);
-	} else if (file_exists("/sbin/cml-service-container")) {
-		file_copy("/sbin/cml-service-container", cservice_bin, -1, 512, 0);
+	} else if (file_exists("/sbin/cml-service-container-static")) {
+		file_copy("/sbin/cml-service-container-static", cservice_bin, -1, 512, 0);
 		INFO("Copied %s to container", cservice_bin);
-	} else if (file_exists("/usr/sbin/cml-service-container")) {
-		file_copy("/usr/sbin/cml-service-container", cservice_bin, -1, 512, 0);
+	} else if (file_exists("/usr/sbin/cml-service-container-static")) {
+		file_copy("/usr/sbin/cml-service-container-static", cservice_bin, -1, 512, 0);
 		INFO("Copied %s to container", cservice_bin);
 	} else {
 		WARN_ERRNO("Could not copy %s to container", cservice_bin);

--- a/service/Makefile
+++ b/service/Makefile
@@ -98,7 +98,7 @@ service: libcommon $(SRC_FILES)
 	$(CC) $(LOCAL_CFLAGS) $(CLAGS) $(SRC_FILES) ${LD_LIB_FLAGS} -o cml-service-container
 
 service-static: libcommon $(SRC_FILES)
-	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES) ${LD_LIB_FLAGS} -o cml-service-container
+	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES) ${LD_LIB_FLAGS} -o cml-service-container-static
 
 exec_cap_systime: libcommon $(SRC_FILES_EXEC_CAP_SYSTIME)
 	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES_EXEC_CAP_SYSTIME) ${LD_LIB_FLAGS} -o exec_cap_systime

--- a/service/Makefile_lsb
+++ b/service/Makefile_lsb
@@ -26,4 +26,4 @@ include Makefile
 SBINDIR := /usr/sbin
 install:
 	mkdir -p ${DESTDIR}${SBINDIR}
-	cp cml-service-container ${DESTDIR}${SBINDIR}/
+	cp cml-service-container-static ${DESTDIR}${SBINDIR}/


### PR DESCRIPTION
This fixes a Lintian error by explicitly marking the binary as static.
Needs https://github.com/gyroidos/meta-trustx/pull/206 for CI.