### PR TITLE
Revert "daemon/audit: hash buffers directly instead of using temporar…

### DIFF
--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -157,17 +157,18 @@ audit_remaining_storage(const char *uuid)
 }
 
 static void
-audit_send_record_cb(const char *hash_string, const unsigned char *hash_buf, size_t hash_buf_len,
+audit_send_record_cb(const char *hash_string, const char *hash_file,
 		     UNUSED crypto_hashalgo_t hash_algo, void *data)
 {
+	uint8_t *buf = NULL;
 	const container_t *c = (const container_t *)data;
 	ASSERT(c);
 
 	// callback is triggert twice for cleanup
 	IF_NULL_RETURN_TRACE(hash_string);
 
-	if (!hash_buf) {
-		ERROR("audit_send_record_cb: hash_buf was empty");
+	if (!hash_file) {
+		ERROR("audit_send_record_cb: hash_file was empty");
 		return;
 	}
 
@@ -176,12 +177,26 @@ audit_send_record_cb(const char *hash_string, const unsigned char *hash_buf, siz
 		return;
 	}
 
-	TRACE_HEXDUMP(hash_buf, hash_buf_len, "Got hash from SCD for buf %s: ", hash_string);
+	uint32_t buf_len = file_size(hash_file);
+	buf = mem_alloc0(buf_len);
+
+	int read = file_read(hash_file, (char *)buf, buf_len);
+
+	if (read < 0 || buf_len != (unsigned int)read) {
+		ERROR("Processing SCD response: read %u bytes, expected %u", read, buf_len);
+		goto out;
+	}
+
+	TRACE("Got hash from SCD for file %s: %s", hash_file, hash_string);
+
+	if (unlink(hash_file)) {
+		ERROR_ERRNO("Failed to unlink %s", hash_file);
+	}
 
 	char *old_acked = mem_strdup(container_audit_get_last_ack(c));
 	container_audit_set_last_ack(c, hash_string);
 
-	if (0 > container_audit_record_send(c, hash_buf, hash_buf_len)) {
+	if (0 > container_audit_record_send(c, buf, buf_len)) {
 		ERROR("Failed to send audit record to container");
 		// rollback
 		container_audit_set_last_ack(c, old_acked);
@@ -195,6 +210,7 @@ audit_send_record_cb(const char *hash_string, const unsigned char *hash_buf, siz
 
 out:
 	container_audit_set_processing_ack(c, false);
+	mem_free0(buf);
 }
 
 static AuditRecord *
@@ -441,6 +457,18 @@ audit_do_send_record(const container_t *c)
 	uint8_t *packed = NULL;
 	uint32_t packed_len = 0;
 	int ret = -1;
+	int fd = -1;
+
+	char tmpfile[strlen(AUDIT_LOGDIR) + 14];
+	if (0 >= sprintf(tmpfile, "%s/%s", AUDIT_LOGDIR, "audit_XXXXXX")) {
+		ERROR_ERRNO("Failed to prepare temporary filename");
+		return -1;
+	}
+
+	if (-1 == (fd = mkstemp(tmpfile))) {
+		ERROR_ERRNO("Failed to generate temporary filename");
+		return -1;
+	}
 
 	CmldToServiceMessage *message_proto = mem_new0(CmldToServiceMessage, 1);
 	cmld_to_service_message__init(message_proto);
@@ -459,13 +487,18 @@ audit_do_send_record(const container_t *c)
 		goto out;
 	}
 
-	TRACE("Requesting scd to hash serialized protobuf message");
+	if (-1 == fd_write(fd, (char *)packed, packed_len)) {
+		ERROR("Failed to write packed message to file.");
+		goto out;
+	}
+
+	TRACE("Requesting scd to hash serialized protobuf message at %s", tmpfile);
 
 	// this state is needed s.t. additional ACKs from container arriving while scd is hashing the file
 	// do not lead to multiple transmissions of the same record
 	container_audit_set_processing_ack(c, true);
 
-	if (crypto_hash_buf(packed, packed_len, AUDIT_HASH_ALGO, audit_send_record_cb, (void *)c)) {
+	if (crypto_hash_file(tmpfile, AUDIT_HASH_ALGO, audit_send_record_cb, (void *)c)) {
 		container_audit_set_processing_ack(c, false);
 		str_t *dump = str_hexdump_new((unsigned char *)packed, (int)packed_len);
 		ERROR("Failed to request hashing of record to be sent with length %u: %s.",
@@ -478,6 +511,8 @@ audit_do_send_record(const container_t *c)
 out:
 	if (ret < 0)
 		ERROR("Failed to send next stored audit record");
+
+	close(fd);
 
 	mem_free0(packed);
 	protobuf_free_message((ProtobufCMessage *)message_proto);


### PR DESCRIPTION
…y files"

This reverts commit ece74f6d8d73ad0842bf91930fe15256cce908d3. Revert this for now since it triggers an assertion in scd.