### PR TITLE
daemon/c_cgroups_sockopt: Fixed typo in c_cgroups_sockopt_prog_free()

### DIFF
--- a/daemon/c_cgroups_sockopt.c
+++ b/daemon/c_cgroups_sockopt.c
@@ -97,7 +97,7 @@ c_cgroups_sockopt_prog_new(const struct bpf_insn *insn, int insn_nr)
 static void
 c_cgroups_sockopt_prog_free(c_cgroups_sockopt_prog_t *prog)
 {
-	IF_NULL_RETUN(prog);
+	IF_NULL_RETURN(prog);
 
 	if (prog->insn)
 		mem_free0(prog->insn);


### PR DESCRIPTION
Fixe typo: IF_NULL_RETUN(prog) -> IF_NULL_RETURN(prog)