### PR TITLE
common/cryptfs: add missing "/" in cryptfs_get_device_path_new()

### DIFF
--- a/common/cryptfs.c
+++ b/common/cryptfs.c
@@ -72,7 +72,7 @@ get_provided_data_sectors(const char *real_blk_name);
 char *
 cryptfs_get_device_path_new(const char *label)
 {
-	return mem_printf("%s%s", DM_PATH_PREFIX, label);
+	return mem_printf("%s/%s", DM_PATH_PREFIX, label);
 }
 
 #if 0


### PR DESCRIPTION
Commit fe960e1c00f6 ("common/dm: Add macro for devfs location") changed the DM_PATH_PREFIX by stripping the trailing "/". This breaks the device path in cryptfs.c. To fix this we need to add the "/" in the format string of the helper cryptfs_get_device_path_new().

This should also fix tpm2d-based encrypted boot of GyroidOS.

Fixes: fe960e1c00f6 ("common/dm: Add macro for devfs location")