### PR TITLE
Refactor automount to own submodule, cleanup c_vol late

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -32,6 +32,7 @@ IDMAPPED ?= n
 CGROUP_V2 ?= y
 CGROUP_SOCKOPT ?= n
 SYSTEMD ?= n
+AUTOMOUNT ?= y
 
 TRUSTME_HARDWARE := x86
 
@@ -148,6 +149,10 @@ SRC_CMODULES += \
 	c_uevent.c \
 	c_hotplug.c \
 	c_seccomp.c
+
+ifeq ($(AUTOMOUNT),y)
+    SRC_CMODULES += c_automount.c
+endif
 
 ifeq ($(OCI),y)
     LOCAL_CFLAGS += -DOCI -I${HOME}/rcs/libocispec/src

--- a/daemon/c_automount.c
+++ b/daemon/c_automount.c
@@ -1,0 +1,291 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2024 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+#define MOD_NAME "c_automount"
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/dir.h"
+#include "common/event.h"
+#include "common/file.h"
+
+#include "container.h"
+
+#include <unistd.h>
+#include <libgen.h>
+#include <sys/inotify.h>
+#include <sys/mount.h>
+#include <sys/sysmacros.h>
+
+#define C_AUTOMOUNT_MOUNT_RETRIES 10
+
+typedef struct c_automount {
+	container_t *container;
+	event_inotify_t *inotify_dev;
+} c_automount_t;
+
+struct c_automount_mount_timer_data {
+	char *path;
+	container_t *container;
+};
+
+static void
+c_automount_mount_timer_cb(event_timer_t *timer, void *data)
+{
+	static int retries = 0;
+	ASSERT(data);
+
+	struct c_automount_mount_timer_data *tdata = data;
+	int ret = 0;
+
+	char *fstypes[] = { "vfat", "ext4", "btrfs", "ext2", "ext3" };
+	char *basename_path = mem_strdup(tdata->path);
+	char *devname = basename(basename_path);
+	char *mount_path = mem_printf("%s/media/external/%s",
+				      container_get_rootdir(tdata->container), devname);
+
+	if (dir_mkdir_p(mount_path, 0755)) {
+		ERROR("Could not create path for external storage mount point");
+		goto out;
+	}
+
+	for (int i = 0; i < 5; ++i) {
+		char *mount_data = NULL;
+		if (!strcmp(fstypes[i], "vfat")) {
+			int uid = container_get_uid(tdata->container);
+			mount_data = mem_printf("uid=%d, gid=%d", uid, uid);
+		}
+
+		ret = mount(tdata->path, mount_path, fstypes[i], MS_RELATIME, mount_data);
+
+		if (mount_data)
+			mem_free0(mount_data);
+
+		if (ret == 0) {
+			INFO("Mounting %s to %s fstype = %s in container %s!", tdata->path,
+			     mount_path, fstypes[i],
+			     uuid_string(container_get_uuid(tdata->container)));
+			break;
+		} else {
+			DEBUG_ERRNO("Failed mounting %s to %s fstype = %s!", tdata->path,
+				    mount_path, fstypes[i]);
+		}
+	}
+
+out:
+	mem_free0(basename_path);
+	mem_free0(mount_path);
+
+	IF_TRUE_RETURN(ret && retries++ < C_AUTOMOUNT_MOUNT_RETRIES);
+
+	retries = 0;
+	mem_free0(tdata->path);
+	mem_free0(tdata);
+
+	event_remove_timer(timer);
+	event_timer_free(timer);
+}
+
+static void
+c_automount_mount_watch_dev_dir_cb(const char *path, uint32_t mask, UNUSED event_inotify_t *inotify,
+				   void *data)
+{
+	ASSERT(data);
+	c_automount_t *automount = data;
+
+	IF_FALSE_RETURN(mask & IN_CREATE);
+
+	struct stat dev_stat;
+	mem_memset(&dev_stat, 0, sizeof(dev_stat));
+
+	if (stat(path, &dev_stat) == -1) {
+		WARN_ERRNO("Could not stat %s", path);
+		return;
+	}
+
+	IF_FALSE_RETURN(S_ISBLK(dev_stat.st_mode));
+
+	DEBUG("blk in container %s: %s (create)", container_get_description(automount->container),
+	      path);
+
+	char type;
+	if (S_ISBLK(dev_stat.st_mode)) {
+		type = 'b';
+	} else if (S_ISCHR(dev_stat.st_mode)) {
+		type = 'c';
+	} else {
+		return;
+	}
+
+	unsigned int major = major(dev_stat.st_rdev);
+	unsigned int minor = minor(dev_stat.st_rdev);
+
+	if (!container_is_device_allowed(automount->container, type, major, minor)) {
+		TRACE("skip not allowed device (%c %d:%d) for container %s", type, major, minor,
+		      container_get_name(automount->container));
+		return;
+	}
+
+	// give device some time to get ready
+	struct c_automount_mount_timer_data *tdata =
+		mem_new0(struct c_automount_mount_timer_data, 1);
+	tdata->path = mem_strdup(path);
+	tdata->container = automount->container;
+	event_timer_t *e = event_timer_new(1000, EVENT_TIMER_REPEAT_FOREVER,
+					   c_automount_mount_timer_cb, tdata);
+	event_add_timer(e);
+}
+
+static void *
+c_automount_new(compartment_t *compartment)
+{
+	ASSERT(compartment);
+	IF_NULL_RETVAL(compartment_get_extension_data(compartment), NULL);
+
+	c_automount_t *automount = mem_new0(c_automount_t, 1);
+	automount->container = compartment_get_extension_data(compartment);
+
+	// watch /dev for device nodes to appear in filesystem
+	automount->inotify_dev = event_inotify_new("/dev", IN_CREATE,
+						   &c_automount_mount_watch_dev_dir_cb, automount);
+
+	return automount;
+}
+
+static void
+c_automount_free(void *automountp)
+{
+	c_automount_t *automount = automountp;
+	ASSERT(automount);
+
+	event_inotify_free(automount->inotify_dev);
+	automount->inotify_dev = NULL;
+
+	mem_free0(automount);
+}
+
+static int
+c_automount_start_child_early(void *automountp)
+{
+	c_automount_t *automount = automountp;
+	ASSERT(automount);
+
+	char *mnt_media = mem_printf("%s/media", container_get_rootdir(automount->container));
+
+	INFO("Mounting tmpfs to %s", mnt_media);
+
+	if (mkdir(mnt_media, 0755) < 0 && errno != EEXIST) {
+		ERROR_ERRNO("Could not mkdir %s", mnt_media);
+		goto error;
+	}
+
+	if (mount("tmpfs", mnt_media, "tmpfs", MS_RELATIME | MS_NOSUID, NULL) < 0) {
+		ERROR_ERRNO("Could not mount %s", mnt_media);
+		goto error;
+	}
+
+	if (mount(NULL, mnt_media, NULL, MS_SHARED, NULL) < 0) {
+		ERROR_ERRNO("Could not apply MS_SHARED to %s", mnt_media);
+		goto error;
+	} else {
+		DEBUG("Applied MS_SHARED to %s", mnt_media);
+	}
+
+	if (container_shift_ids(automount->container, mnt_media, mnt_media, NULL)) {
+		ERROR_ERRNO("Could not shift ids for dev on '%s'", mnt_media);
+		goto error;
+	}
+
+	mem_free0(mnt_media);
+	return 0;
+error:
+	mem_free0(mnt_media);
+	return -COMPARTMENT_ERROR;
+}
+
+static int
+c_automount_start_post_exec(void *automountp)
+{
+	c_automount_t *automount = automountp;
+	ASSERT(automount);
+
+	/* start watching device nodes for automount */
+	int error = event_add_inotify(automount->inotify_dev);
+	if (error && error != -EEXIST) {
+		ERROR("Could not register inotify event for automount events!");
+		return -COMPARTMENT_ERROR;
+	}
+
+	return 0;
+}
+
+static int
+c_automount_stop(void *automountp)
+{
+	c_automount_t *automount = automountp;
+	ASSERT(automount);
+
+	event_remove_inotify(automount->inotify_dev);
+
+	return 0;
+}
+
+static void
+c_automount_cleanup(void *automountp, UNUSED bool rebooting)
+{
+	c_automount_t *automount = automountp;
+	ASSERT(automount);
+
+	char *mnt_media = mem_printf("%s/media", container_get_rootdir(automount->container));
+	if (umount(mnt_media) < 0)
+		WARN_ERRNO("Could not umount %s", mnt_media);
+
+	mem_free0(mnt_media);
+}
+
+static compartment_module_t c_automount_module = {
+	.name = MOD_NAME,
+	.compartment_new = c_automount_new,
+	.compartment_free = c_automount_free,
+	.compartment_destroy = NULL,
+	.start_post_clone_early = NULL,
+	.start_child_early = c_automount_start_child_early,
+	.start_pre_clone = NULL,
+	.start_post_clone = NULL,
+	.start_pre_exec = NULL,
+	.start_post_exec = c_automount_start_post_exec,
+	.start_child = NULL,
+	.start_pre_exec_child = NULL,
+	.stop = c_automount_stop,
+	.cleanup = c_automount_cleanup,
+	.join_ns = NULL,
+};
+
+static void INIT
+c_automount_init(void)
+{
+	// register this module in compartment.c
+	compartment_register_module(&c_automount_module);
+}

--- a/daemon/c_uevent.c
+++ b/daemon/c_uevent.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of GyroidOS
- * Copyright(c) 2013 - 2022 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2024 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -35,18 +35,13 @@
 
 #include "container.h"
 
-#include <unistd.h>
 #include <libgen.h>
-#include <sys/inotify.h>
-#include <sys/mount.h>
 #include <sys/sysmacros.h>
-
-#define C_UEVENT_AUTO_MOUNT_RETRIES 10
+#include <unistd.h>
 
 typedef struct c_uevent {
 	container_t *container;
 	uevent_uev_t *uev;
-	event_inotify_t *inotify_dev;
 } c_uevent_t;
 
 static int
@@ -87,117 +82,6 @@ shift:
 err:
 	mem_free0(path_dirname);
 	return -1;
-}
-
-struct c_uevent_mount_timer_data {
-	char *path;
-	container_t *container;
-};
-
-static void
-c_uevent_mount_timer_cb(event_timer_t *timer, void *data)
-{
-	static int retries = 0;
-	ASSERT(data);
-
-	struct c_uevent_mount_timer_data *tdata = data;
-	int ret = 0;
-
-	char *fstypes[] = { "vfat", "ext4", "btrfs", "ext2", "ext3" };
-	char *basename_path = mem_strdup(tdata->path);
-	char *devname = basename(basename_path);
-	char *mount_path = mem_printf("%s/media/external/%s",
-				      container_get_rootdir(tdata->container), devname);
-
-	if (dir_mkdir_p(mount_path, 0755)) {
-		ERROR("Could not create path for external storage mount point");
-		goto out;
-	}
-
-	for (int i = 0; i < 5; ++i) {
-		char *mount_data = NULL;
-		if (!strcmp(fstypes[i], "vfat")) {
-			int uid = container_get_uid(tdata->container);
-			mount_data = mem_printf("uid=%d, gid=%d", uid, uid);
-		}
-
-		ret = mount(tdata->path, mount_path, fstypes[i], MS_RELATIME, mount_data);
-
-		if (mount_data)
-			mem_free0(mount_data);
-
-		if (ret == 0) {
-			INFO("Mounting %s to %s fstype = %s in container %s!", tdata->path,
-			     mount_path, fstypes[i],
-			     uuid_string(container_get_uuid(tdata->container)));
-			break;
-		} else {
-			DEBUG_ERRNO("Failed mounting %s to %s fstype = %s!", tdata->path,
-				    mount_path, fstypes[i]);
-		}
-	}
-
-out:
-	mem_free0(basename_path);
-	mem_free0(mount_path);
-
-	IF_TRUE_RETURN(ret && retries++ < C_UEVENT_AUTO_MOUNT_RETRIES);
-
-	retries = 0;
-	mem_free0(tdata->path);
-	mem_free0(tdata);
-
-	event_remove_timer(timer);
-	event_timer_free(timer);
-}
-
-static void
-c_uevent_mount_watch_dev_dir_cb(const char *path, uint32_t mask, UNUSED event_inotify_t *inotify,
-				void *data)
-{
-	ASSERT(data);
-	c_uevent_t *uevent = data;
-
-	IF_FALSE_RETURN(mask & IN_CREATE);
-
-	struct stat dev_stat;
-	mem_memset(&dev_stat, 0, sizeof(dev_stat));
-
-	if (stat(path, &dev_stat) == -1) {
-		WARN_ERRNO("Could not stat %s", path);
-		return;
-	}
-
-	IF_FALSE_RETURN(S_ISBLK(dev_stat.st_mode));
-
-	DEBUG("blk in container %s: %s (create)", container_get_description(uevent->container),
-	      path);
-
-	char type;
-	if (S_ISBLK(dev_stat.st_mode)) {
-		type = 'b';
-	} else if (S_ISCHR(dev_stat.st_mode)) {
-		type = 'c';
-	} else {
-		return;
-	}
-
-	unsigned int major = major(dev_stat.st_rdev);
-	unsigned int minor = minor(dev_stat.st_rdev);
-
-	if (!container_is_device_allowed(uevent->container, type, major, minor)) {
-		TRACE("skip not allowed device (%c %d:%d) for container %s", type, major, minor,
-		      container_get_name(uevent->container));
-		return;
-	}
-
-	// give device some time to get ready
-	struct c_uevent_mount_timer_data *tdata = mem_new0(struct c_uevent_mount_timer_data, 1);
-	tdata->path = mem_strdup(path);
-	tdata->container = uevent->container;
-	event_timer_t *e =
-		event_timer_new(1000, EVENT_TIMER_REPEAT_FOREVER, c_uevent_mount_timer_cb, tdata);
-	event_add_timer(e);
 }
 
 static void
@@ -288,10 +172,6 @@ c_uevent_new(compartment_t *compartment)
 			       UEVENT_ACTION_ADD | UEVENT_ACTION_CHANGE | UEVENT_ACTION_REMOVE,
 			       c_uevent_handle_event_cb, uevent);
 
-	// watch /dev for device nodes to appear in filesystem
-	uevent->inotify_dev =
-		event_inotify_new("/dev", IN_CREATE, &c_uevent_mount_watch_dev_dir_cb, uevent);
-
 	return uevent;
 }
 
@@ -302,9 +182,6 @@ c_uevent_free(void *ueventp)
 	ASSERT(uevent);
 
 	uevent_uev_free(uevent->uev);
-
-	event_inotify_free(uevent->inotify_dev);
-	uevent->inotify_dev = NULL;
 
 	mem_free0(uevent);
 }
@@ -345,45 +222,6 @@ c_uevent_boot_complete_cb(container_t *container, container_callback_t *cb, void
 }
 
 static int
-c_uevent_start_child_early(void *ueventp)
-{
-	c_uevent_t *uevent = ueventp;
-	ASSERT(uevent);
-
-	char *mnt_media = mem_printf("%s/media", container_get_rootdir(uevent->container));
-
-	INFO("Mounting tmpfs to %s", mnt_media);
-
-	if (mkdir(mnt_media, 0755) < 0 && errno != EEXIST) {
-		ERROR_ERRNO("Could not mkdir %s", mnt_media);
-		goto error;
-	}
-
-	if (mount("tmpfs", mnt_media, "tmpfs", MS_RELATIME | MS_NOSUID, NULL) < 0) {
-		ERROR_ERRNO("Could not mount %s", mnt_media);
-		goto error;
-	}
-
-	if (mount(NULL, mnt_media, NULL, MS_SHARED, NULL) < 0) {
-		ERROR_ERRNO("Could not apply MS_SHARED to %s", mnt_media);
-		goto error;
-	} else {
-		DEBUG("Applied MS_SHARED to %s", mnt_media);
-	}
-
-	if (container_shift_ids(uevent->container, mnt_media, mnt_media, NULL)) {
-		ERROR_ERRNO("Could not shift ids for dev on '%s'", mnt_media);
-		goto error;
-	}
-
-	mem_free0(mnt_media);
-	return 0;
-error:
-	mem_free0(mnt_media);
-	return -COMPARTMENT_ERROR;
-}
-
-static int
 c_uevent_start_post_exec(void *ueventp)
 {
 	c_uevent_t *uevent = ueventp;
@@ -392,13 +230,6 @@ c_uevent_start_post_exec(void *ueventp)
 	// register uevent handling for this c_uevent container submodule
 	if (uevent_add_uev(uevent->uev))
 		return -COMPARTMENT_ERROR;
-
-	/* start watching device nodes for automount */
-	int error = event_add_inotify(uevent->inotify_dev);
-	if (error && error != -EEXIST) {
-		ERROR("Could not register inotify event for automount events!");
-		return -COMPARTMENT_ERROR;
-	}
 
 	/* register an observer to wait for the container to be running */
 	if (!container_register_observer(uevent->container, &c_uevent_boot_complete_cb, uevent)) {
@@ -417,8 +248,6 @@ c_uevent_stop(void *ueventp)
 
 	uevent_remove_uev(uevent->uev);
 
-	event_remove_inotify(uevent->inotify_dev);
-
 	return 0;
 }
 
@@ -428,11 +257,9 @@ c_uevent_cleanup(void *ueventp, UNUSED bool rebooting)
 	c_uevent_t *uevent = ueventp;
 	ASSERT(uevent);
 
-	char *mnt_media = mem_printf("%s/media", container_get_rootdir(uevent->container));
-	if (umount(mnt_media) < 0)
-		WARN_ERRNO("Could not umount %s", mnt_media);
-
-	mem_free0(mnt_media);
+	// if killed, stop hook may not be called. Thus remove
+	// uev if still in list if not this will not harm.
+	uevent_remove_uev(uevent->uev);
 }
 
 static compartment_module_t c_uevent_module = {
@@ -441,7 +268,7 @@ static compartment_module_t c_uevent_module = {
 	.compartment_free = c_uevent_free,
 	.compartment_destroy = NULL,
 	.start_post_clone_early = NULL,
-	.start_child_early = c_uevent_start_child_early,
+	.start_child_early = NULL,
 	.start_pre_clone = NULL,
 	.start_post_clone = NULL,
 	.start_pre_exec = NULL,

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1970,6 +1970,7 @@ static compartment_module_t c_vol_module = {
 	.stop = NULL,
 	.cleanup = c_vol_cleanup,
 	.join_ns = NULL,
+	.flags = COMPARTMENT_MODULE_F_CLEANUP_LATE,
 };
 
 static void INIT

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -529,42 +529,6 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 		// overwrite image sizes of mount table
 		container_config_fill_mount(conf, container_get_mnt(c));
 		container_config_write(conf);
-
-		// check if enough disk space is available
-		mount_t *mnt_table = container_get_mnt(c);
-		off_t disk_space_required = mount_get_disk_usage_container(mnt_table);
-		if (disk_space_required < 0) {
-			ERROR("Function mount_get_disk_usage_container failed");
-			container_free(c);
-			c = NULL;
-			goto out_config;
-		}
-
-		off_t disk_space_available = file_disk_space_free(store_path);
-		if (disk_space_available < 0) {
-			ERROR("Function file_disk_space_free failed");
-			container_free(c);
-			c = NULL;
-			goto out_config;
-		}
-
-		off_t min_free_space = file_disk_space(store_path);
-		if (min_free_space < 0) {
-			ERROR("Function file_disk_space failed");
-			container_free(c);
-			c = NULL;
-			goto out_config;
-		}
-		min_free_space *= CMLD_STORAGE_FREE_THRESHOLD;
-
-		if (disk_space_required > disk_space_available ||
-		    (disk_space_available - disk_space_required) < min_free_space) {
-			// not enough space left
-			ERROR("Not enough disk space left");
-			container_free(c);
-			c = NULL;
-			goto out_config;
-		}
 	}
 
 out_config:
@@ -1575,6 +1539,45 @@ cmld_container_create_clone(container_t *container)
 	return NULL;
 }
 
+static container_t *
+cmld_container_validate_disk_space(container_t *container, const char *store_path)
+{
+	IF_NULL_RETVAL(container, NULL);
+
+	// check if enough disk space is available
+	mount_t *mnt_table = container_get_mnt(container);
+	off_t disk_space_required = mount_get_disk_usage_container(mnt_table);
+	if (disk_space_required < 0) {
+		ERROR("Function mount_get_disk_usage_container failed");
+		goto err;
+	}
+
+	off_t disk_space_available = file_disk_space_free(store_path);
+	if (disk_space_available < 0) {
+		ERROR("Function file_disk_space_free failed");
+		goto err;
+	}
+
+	off_t min_free_space = file_disk_space(store_path);
+	if (min_free_space < 0) {
+		ERROR("Function file_disk_space failed");
+		goto err;
+	}
+	min_free_space *= CMLD_STORAGE_FREE_THRESHOLD;
+
+	if (disk_space_required > disk_space_available ||
+	    (disk_space_available - disk_space_required) < min_free_space) {
+		// not enough space left
+		ERROR("Not enough disk space left");
+		goto err;
+	}
+
+	return container;
+err:
+	mem_free0(container);
+	return NULL;
+}
+
 container_t *
 cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint8_t *sig,
 				  size_t sig_len, uint8_t *cert, size_t cert_len)
@@ -1586,6 +1589,9 @@ cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint
 
 	container_t *c =
 		cmld_container_new(path, NULL, config, config_len, sig, sig_len, cert, cert_len);
+
+	// will free container object if insufficient space available
+	c = cmld_container_validate_disk_space(c, path);
 	if (c) {
 		cmld_containers_list = list_append(cmld_containers_list, c);
 		/*

--- a/daemon/compartment.h
+++ b/daemon/compartment.h
@@ -123,7 +123,16 @@ typedef struct compartment_module {
 	int (*stop)(void *data);
 	void (*cleanup)(void *data, bool rebooting);
 	int (*join_ns)(void *data);
+	int flags;
 } compartment_module_t;
+
+/* If COMPARTMENT_MODULE_F_CLEANUP_LATE is used, the call to
+ * module cleanup() is postponed to after all modules without
+ * that flag. Remember if more than one module has this flag set,
+ * the order in which the modules are registered also applies to
+ * the late cleanup.
+ */
+#define COMPARTMENT_MODULE_F_CLEANUP_LATE (1U << 0)
 
 void
 compartment_register_module(compartment_module_t *mod);


### PR DESCRIPTION
Removed automount feature from c_uevent. Added it to c_automount.
This allows for disable automount at build, since it seems to brick start/stop cycles on some systems.
Use new module flag to cleanup c_vol late after any other module for now. This should also fix
start/stop cycles if c_automount is enabled.