### PR TITLE
Module loding for containers

### DIFF
--- a/common/proc.h
+++ b/common/proc.h
@@ -129,4 +129,14 @@ proc_get_mem_available(const proc_meminfo_t *meminfo);
 int
 proc_waitpid(pid_t pid, int *status, int options);
 
+/**
+ * Returns the name of the file which was used when the file descriptor
+ * fd was opened.
+ * @param pid The pid of the process which opened the fd
+ * @param fd The file descriptor
+ * @return path of the file when fd was opened, NULL on error
+ */
+char *
+proc_get_filename_of_fd_new(pid_t pid, int fd);
+
 #endif /* PROC_H */

--- a/common/proc.h
+++ b/common/proc.h
@@ -25,6 +25,7 @@
 #define PROC_H
 
 #include <unistd.h>
+#include <stdint.h>
 
 typedef struct proc_status proc_status_t;
 
@@ -39,6 +40,12 @@ proc_status_get_name(const proc_status_t *status);
 
 pid_t
 proc_status_get_ppid(const proc_status_t *status);
+
+uint64_t
+proc_status_get_cap_prm(const proc_status_t *status);
+
+uint64_t
+proc_status_get_cap_eff(const proc_status_t *status);
 
 /**
  * Kills a process/service with a given name. If ppid is bigger

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -43,6 +43,7 @@
 
 typedef struct c_cap {
 	container_t *container;
+	compartment_t *compartment;
 } c_cap_t;
 
 static void *
@@ -53,6 +54,7 @@ c_cap_new(compartment_t *compartment)
 
 	c_cap_t *cap = mem_new0(c_cap_t, 1);
 	cap->container = compartment_get_extension_data(compartment);
+	cap->compartment = compartment;
 
 	return cap;
 }
@@ -84,8 +86,9 @@ c_cap_set_current_process(void *capp)
 	/* 9 */ C_CAP_DROP(CAP_LINUX_IMMUTABLE);
 	/* 14 */ C_CAP_DROP(CAP_IPC_LOCK);
 	/* 15 */ C_CAP_DROP(CAP_IPC_OWNER);
-	/* 16 */ C_CAP_DROP(CAP_SYS_MODULE);
-	///* 17 */ C_CAP_DROP(CAP_SYS_RAWIO); /* does NOT work */
+	if (!(COMPARTMENT_FLAG_MODULE_LOAD & compartment_get_flags(cap->compartment)))
+		/* 16 */ C_CAP_DROP(CAP_SYS_MODULE);
+		///* 17 */ C_CAP_DROP(CAP_SYS_RAWIO); /* does NOT work */
 #ifndef DEBUG_BUILD
 	/* 19 */ C_CAP_DROP(CAP_SYS_PTRACE);
 #endif

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1445,6 +1445,12 @@ c_vol_new(compartment_t *compartment)
 		container_init_env_prepend(vol->container, guestos_get_init_env(vol->os),
 					   guestos_get_init_env_len(vol->os));
 	}
+
+	// mount modules inside container
+	if (compartment_get_flags(compartment) & COMPARTMENT_FLAG_MODULE_LOAD)
+		mount_add_entry(vol->mnt, MOUNT_TYPE_BIND_DIR, "/lib/modules", "/lib/modules",
+				"none", 0);
+
 	return vol;
 }
 

--- a/daemon/cc_mode/container.proto
+++ b/daemon/cc_mode/container.proto
@@ -98,6 +98,9 @@ message ContainerConfig {
 	// a list of network interfaces assigned to this container
 	repeated ContainerPnetConfig net_ifaces = 23;
 
+	// a list of modules explicitely allowed for this container
+	repeated string allow_module = 24;
+
 	// a list of devices explicitely allowed for this container
 	repeated string allow_dev = 25;
 

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -401,6 +401,7 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 	uint64_t new_guestos_version;
 	bool allow_autostart;
 	bool allow_system_time;
+	list_t *allowed_module_list;
 	char **allowed_devices;
 	char **assigned_devices;
 	const char *init;
@@ -497,6 +498,7 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 					NULL;
 	list_t *usbdev_list = container_config_get_usbdev_list_new(conf);
 
+	allowed_module_list = container_config_get_module_allow_list_new(conf);
 	allowed_devices = container_config_get_dev_allow_list_new(conf);
 	assigned_devices = container_config_get_dev_assign_list_new(conf);
 
@@ -524,9 +526,9 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 
 	c = container_new(uuid, name, type, ns_usr, ns_net, os, config_filename, images_dir,
 			  ram_limit, cpus_allowed, color, allow_autostart, allow_system_time,
-			  dns_server, pnet_cfg_list, allowed_devices, assigned_devices,
-			  vnet_cfg_list, usbdev_list, init, init_argv, init_env, init_env_len,
-			  fifo_list, ttype, usb_pin_entry);
+			  dns_server, pnet_cfg_list, allowed_module_list, allowed_devices,
+			  assigned_devices, vnet_cfg_list, usbdev_list, init, init_argv, init_env,
+			  init_env_len, fifo_list, ttype, usb_pin_entry);
 	if (c) {
 		// overwrite image sizes of mount table
 		container_config_fill_mount(conf, container_get_mnt(c));
@@ -1251,7 +1253,7 @@ cmld_init_c0(const char *path, const char *c0os)
 	container_t *new_c0 =
 		container_new(c0_uuid, "c0", CONTAINER_TYPE_CONTAINER, false, c0_ns_net, c0_os,
 			      NULL, c0_images_folder, c0_ram_limit, NULL, 0xffffff00, false, false,
-			      cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL, init,
+			      cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL, NULL, init,
 			      init_argv, NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false);
 
 	/* store c0 as first element of the cmld_containers_list */

--- a/daemon/compartment.h
+++ b/daemon/compartment.h
@@ -70,6 +70,7 @@ typedef struct compartment_extension compartment_extension_t;
 #define COMPARTMENT_FLAG_NS_NET 0x0000000000000008
 #define COMPARTMENT_FLAG_NS_IPC 0x0000000000000010
 #define COMPARTMENT_FLAG_SYSTEM_TIME 0x0000000000000020
+#define COMPARTMENT_FLAG_MODULE_LOAD 0x0000000000000040
 
 /**
  * Represents the current compartment state.

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -148,13 +148,13 @@ enum container_smartcard_error {
  */
 container_t *
 container_new(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr, bool ns_net,
-	      const void *os, const char *config_filename, const char *images_folder,
+	      const void *os, const char *config_filename, const char *images_dir,
 	      unsigned int ram_limit, const char *cpus_allowed, uint32_t color,
 	      bool allow_autostart, bool allow_system_time, const char *dns_server,
-	      list_t *net_ifaces, char **allowed_devices, char **assigned_devices,
-	      list_t *vnet_cfg_list, list_t *usbdev_list, const char *init, char **init_argv,
-	      char **init_env, size_t init_env_len, list_t *fifo_list, container_token_type_t ttype,
-	      bool usb_pin_entry);
+	      list_t *pnet_cfg_list, list_t *allowed_module_list, char **allowed_devices,
+	      char **assigned_devices, list_t *vnet_cfg_list, list_t *usbdev_list, const char *init,
+	      char **init_argv, char **init_env, size_t init_env_len, list_t *fifo_list,
+	      container_token_type_t ttype, bool usb_pin_entry);
 
 /**
  * Free a container data structure.
@@ -364,6 +364,12 @@ container_pnet_cfg_set_pnet_name(container_pnet_cfg_t *pnet_cfg, const char *pne
  */
 list_t *
 container_get_usbdev_list(const container_t *container);
+
+/**
+ * Get the list of module names which are allowed in container config.
+ */
+const list_t *
+container_get_module_allow_list(const container_t *container);
 
 const char **
 container_get_dev_allow_list(const container_t *container);

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -110,6 +110,9 @@ message ContainerConfig {
 	// a list of network interfaces assigned to this container
 	repeated ContainerPnetConfig net_ifaces = 23;
 
+	// a list of modules explicitely allowed for this container
+	repeated string allow_module = 24;
+
 	// a list of devices explicitely allowed for this container
 	repeated string allow_dev = 25;
 

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -435,6 +435,19 @@ container_config_get_net_ifaces_list_new(const container_config_t *config)
 	return net_ifaces_list;
 }
 
+list_t *
+container_config_get_module_allow_list_new(const container_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+
+	list_t *module_list = NULL;
+	for (size_t i = 0; i < config->cfg->n_allow_module; ++i) {
+		module_list = list_append(module_list, mem_strdup(config->cfg->allow_module[i]));
+	}
+	return module_list;
+}
+
 char **
 container_config_get_dev_allow_list_new(const container_config_t *config)
 {

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -154,9 +154,18 @@ list_t *
 container_config_get_net_ifaces_list_new(const container_config_t *config);
 
 /**
+ * Provides the list of modules explicitely allowed for the container
+ *
+ * Module loading is only allowed if the kernel enforces signatures.
+ * Further, the acctual modules are loaded from the cmld's mount view.
+ * Thus, no binary from the container itself is passed to the kernel.
+ */
+list_t *
+container_config_get_module_allow_list_new(const container_config_t *config);
+
+/**
  * Provides the list of hardware devices explicitely allowed for the container from the container's config file
  */
-
 char **
 container_config_get_dev_allow_list_new(const container_config_t *config);
 

--- a/daemon/mount.h
+++ b/daemon/mount.h
@@ -66,7 +66,8 @@ enum mount_type {
 				      as overlay to each container */
 	MOUNT_TYPE_BIND_FILE = 10,    /**< file is bind mounted to container (RO) */
 	MOUNT_TYPE_BIND_FILE_RW = 11, /**< file is bind mounted to container (RW) */
-	MOUNT_TYPE_BIND_DIR = 12,     /**< dir is bind mounted to container (RW) */
+	MOUNT_TYPE_BIND_DIR = 12,     /**< dir is bind mounted to container (RO) */
+	MOUNT_TYPE_BIND_DIR_RW = 13,  /**< dir is bind mounted to container (RW) */
 };
 
 mount_t *


### PR DESCRIPTION
main commits which holds the feature are:

[daemon/compartment: Introduce new flag COMPARTMENT_FLAG_MODULE_LOAD](https://github.com/gyroidos/cml/commit/bc3b8c6f8a6c5e5917fc3b201bffe87c79de53b7)
The new flag COMPARTMENT_FLAG_MODULE_LOAD will be used in followup
commits to emulated module loading for those containers which have
this flag set.

Only allow this flag to make it to the internal compartment struct if
module signatures are enforced in the running kernel. We use the new
helper compartment_is_module_sig_enforced(void) to check the
proc file "sys/module/module/parameters/sig_enforce" which says "Y"
in that case.

If compartment flag is set we now emulate the finit_module() syscall.
The emulation does properly check that the corresponding process
holds the CAP_SYS_MODULE in its namespace.

[daemon/c_seccomp: Handle finit_module() syscall](https://github.com/gyroidos/cml/commit/b5306a29e4af26ffa6d8dda5a93a1ed9e3623159)
Further, module flags are sanitised to strip out 'bad' flags such as
MODULE_INIT_IGNORE_MODVERSIONS and MODULE_INIT_IGNORE_VERMAGIC.
We use a mask which currently only allows MODULE_INIT_COMPRESSED_FILE.
Current kernel only have this three flags. To be safe if new less
secure module flags are introduced, we use this mask approach.

Module parameters are passed as is.

[daemon/c_seccomp: check allowed list during finit_module() emulation](https://github.com/gyroidos/cml/pull/453/commits/649fc4f4bc0919632a5d12a9f17ae150c9c6b934)

In c_seccomp_new(), use the allowed list from the container object
(config) to retrieve a list of modules according the dependencies in
'modules.dep' file and store this in the c_seccomp struct.

Later during emulation check if the module name is in the generated
list of allowed modules and their depending modules, if not drop out
of emulation early.