### PR TITLE
mknod emulation

### DIFF
--- a/common/proc.c
+++ b/common/proc.c
@@ -459,3 +459,22 @@ proc_get_filename_of_fd_new(pid_t pid, int fd)
 	mem_free0(path);
 	return ret;
 }
+
+char *
+proc_get_cwd_new(pid_t pid)
+{
+	char *ret;
+
+	char *file_path = mem_alloc0(PATH_MAX);
+	char *path = mem_printf("/proc/%d/cwd", pid);
+
+	ssize_t len = readlink(path, file_path, PATH_MAX);
+	if (len < 0 || len > PATH_MAX - 1)
+		ERROR_ERRNO("readlink on %s returned %zd", path, len);
+
+	ret = (len < 0 || len > PATH_MAX - 1) ? NULL : mem_strdup(file_path);
+
+	mem_free0(file_path);
+	mem_free0(path);
+	return ret;
+}

--- a/common/proc.h
+++ b/common/proc.h
@@ -146,4 +146,12 @@ proc_waitpid(pid_t pid, int *status, int options);
 char *
 proc_get_filename_of_fd_new(pid_t pid, int fd);
 
+/**
+ * Returns the current working dir of a process
+ * @param pid The pid of the process
+ * @return path of the cwd of the process with pid pid, NULL on error
+ */
+char *
+proc_get_cwd_new(pid_t pid);
+
 #endif /* PROC_H */

--- a/daemon/c_cgroups_dev.c
+++ b/daemon/c_cgroups_dev.c
@@ -111,6 +111,8 @@ static const char *c_cgroups_dev_generic_whitelist[] = {
 	/*************/
 	/* Character */
 
+	"c 0:0 rwm", // Overlayfs whiteouts
+
 	/* Memory Devices */
 	//"c 1:1 rwm", // physical mem
 	//"c 1:2 rwm", // kmem

--- a/daemon/c_seccomp.c
+++ b/daemon/c_seccomp.c
@@ -190,11 +190,6 @@ typedef struct c_seccomp {
 	list_t *module_list; /* names of modules loaded by this compartment */
 } c_seccomp_t;
 
-/**
- * slightly modified sample code from the seccomp manpage
- * https://man7.org/linux/man-pages/man2/seccomp.2.html
- * an the Linux secomp sample code at samples/seccomp
- */
 static int
 c_seccomp_install_filter()
 {


### PR DESCRIPTION
Main commit:
[daemon/c_seccomp: handle mknod() and mknodat()](https://github.com/gyroidos/cml/pull/454/commits/a4e419ba938ac922bd4ce8d80d5c42fbe94382d3)

We only do user space emulation for block and char devices, otherwise
the bpf-based secompfilter directly jumps to SECCOMP_RET_ALLOW and let
the kernel process the syscall.

We emulate mknod() by mknodat() for code dedup. mknod() and mknodat()
have the same arguments, except that mknodat has dirfd as first argument:

  int mknod(const char *pathname, mode_t mode, dev_t dev);
  int mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev);

We therefore use an offset +1 for the data.args array to retrieve syscall
parameters from seccomp req in case of mknodat() and set dirfd to AT_FDCWD
in case of mknod().

Further, we check CAP_MKNOD of the container process and if the c_cgroups
submodule of the container allows the device access.

The actual syscall execution is made in a forked child which joins the
mount namespace of the container. We also change to the mapped root user
uid. Otherwise, if we just use system root with uid 0, we cannot write
mounts mounted by the container itself, e.g. '/tmp'. This would result in
an "errno (75: Value too large for defined data type)".
To still allow mknod we need to preserve CAP_MKNOD for the forked child.

Further, we need to switch to the current working directory of the
target process for which we do the emulation. proc_get_cwd_new() is used
to retrieve the CWD before switching namespaces. In the forked child,
just a chdir() to that directory is made then.