### PR TITLE
daemon/{c_cgroups,c_cgroups_sockopt}: Remove hardware.h include

### DIFF
--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -35,7 +35,6 @@
 #define _GNU_SOURCE
 #include <string.h>
 
-#include "hardware.h"
 #include "cmld.h"
 #include "mount.h"
 

--- a/daemon/c_cgroups_sockopt.c
+++ b/daemon/c_cgroups_sockopt.c
@@ -49,7 +49,6 @@
 #include <unistd.h>
 
 #include "container.h"
-#include "hardware.h"
 #include "bpf_insn.h"
 
 // cgroup subtree where cmld is running in (provided by c_cgroups_v2.c)


### PR DESCRIPTION
Inclusion of hardware.h was missed during testing because the modules are deactivated in the default build configuration.