### PR TITLE
daemon/c_idmapped and cmld fixes

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -668,7 +668,7 @@ cmld_load_containers_cb(const char *path, const char *name, UNUSED void *data)
 		goto cleanup;
 	}
 
-	if (cmld_reload_container((const uuid_t *)uuid, path) != 0) {
+	if (cmld_reload_container((const uuid_t *)uuid, path) == NULL) {
 		WARN("Failed to reload container");
 		goto cleanup;
 	}


### PR DESCRIPTION
**daemon/c_idmapped: properly set overlayfs mount options in userns**

Do not set metacopy=on if mounting in userns. Further, use userxattr to use "user.overlay." xattr namespace instead of "trusted.overlay.". Unprivileged writing "trusted." xattrs would require CAP_SYS_ADMIN in the initial userns.

This fixes following warnings in demsg:

   [264523.592857] overlayfs: failed to set xattr on upper
   [264523.592864] overlayfs: ...falling back to redirect_dir=nofollow.
   [264523.592866] overlayfs: ...falling back to metacopy=off.
   [264523.592867] overlayfs: ...falling back to uuid=null.
   [264523.592868] overlayfs: try mounting with 'userxattr' option

Fixes: 8d5c9f4d85a7 ("daemon/c_idmapped: New module for idmapped mounts to replace c_shiftid")


**daemon/cmld: Handle cmld_reload_container return value properly**

Commit https://github.com/quitschbo/cml/commit/e816bafc026a43ab1ea7c1e804b951c957874288 "daemon/cmld: Properly register config_sync_cb"
changed the return value from int to container_t*.
Thus, we also have to check if its '== NULL' for error handling in
cmld_load_containers_cb().

This avoids the following missleading warning:
 [403] <DEBUG> cmld.c+616: Loaded config for container ridux0
 [403] <WARN>  cmld.c+668: Failed to reload container

Fixes: https://github.com/quitschbo/cml/commit/e816bafc026a43ab1ea7c1e804b951c957874288 ("daemon/cmld: Properly register config_sync_cb")