### PR TITLE
daemon/hotplug: trigger all net devices (add) uevents on early boot

### DIFF
--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -115,6 +115,12 @@ hotplug_rename_ifi_new(const char *oldname, const char *infix)
 	unsigned int *ifi_idx;
 	char *newname = NULL;
 
+	// do not rename twice
+	if (!strncmp(oldname, "cml", 3)) {
+		DEBUG("Keeping ifname %s", oldname);
+		return mem_strdup(oldname);
+	}
+
 	ifi_idx = !strcmp(infix, "wlan") ? &cmld_wlan_idx : &cmld_eth_idx;
 
 	if (-1 == asprintf(&newname, "%s%s%d", "cml", infix, *ifi_idx)) {


### PR DESCRIPTION
The current procedure to activate all devices in the CML init script and then added all available network interfaces to the cmld's internal tracking list, is racy.

E.g., the modprobe for a driver will be made by 'init' which will create the corresponding net device. However there is some time needed until the corresponding sysfs structures are populated. The cmld gets startet and initializes its internal list of net devices on basis if '/sys/class/net/<ifname>' is present. This is not always ready at then. The result is that the corresponding net interface will not be added to the internal tracking list and stays in the init root netns forever.

Thus, to avoid missing some interface get moved to c0 on stratup, let hotplug_init() trigger all relevant events again. That way the hotplug module will handle those devices as just hot plugged ones. The mechanism in place uses a timed callback for the sysfs to be populated.