### PR TITLE
daemon/cmld: Check available disk space on container config update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
 
 	parameters {
 		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
+		string(name: 'CI_LIB_VERSION', defaultValue: 'main', description: 'Version of the gyroidos_ci_common library to be used')
 	}
 
 	stages {
@@ -29,7 +30,8 @@ pipeline {
 				}
 
 				build job: "../gyroidos/${BASE_BRANCH}", wait: true, parameters: [
-					string(name: "PR_BRANCHES", value: "${REPO_NAME}=${env.BRANCH_NAME},${env.PR_BRANCHES}")
+					string(name: "PR_BRANCHES", value: "${REPO_NAME}=${env.BRANCH_NAME},${env.PR_BRANCHES}"),
+					string(name: "CI_LIB_VERSION", value: "${CI_LIB_VERSION}")
 				]
 			}
 		}

--- a/common/file.c
+++ b/common/file.c
@@ -430,3 +430,25 @@ file_disk_space_used(const char *path)
 
 	return (s.f_blocks - s.f_bfree) * s.f_frsize;
 }
+
+bool
+file_disk_space_available(const char *path, off_t required, float threshold)
+{
+	ASSERT(path);
+	IF_TRUE_RETVAL_ERROR((threshold < 0 || threshold > 1), false);
+
+	off_t available = file_disk_space_free(path);
+	IF_TRUE_RETVAL_ERROR(available < 0, false);
+
+	off_t min_free_space = file_disk_space(path);
+	IF_TRUE_RETVAL_ERROR(min_free_space < 0, false);
+
+	min_free_space *= threshold;
+
+	if (required > available || (available - required) < min_free_space) {
+		ERROR("Not enough disk space left");
+		return false;
+	}
+
+	return true;
+}

--- a/common/file.h
+++ b/common/file.h
@@ -198,12 +198,23 @@ off_t
 file_disk_space_free(const char *path);
 
 /**
- * get free used disk space of underlying file system of the corresponding
+ * get used disk space of underlying file system of the corresponding
  * file or directory at path.
  * @param path The file name or directory name
  * @return The used disk space of the file system for the given path or -1 on error.
  */
 off_t
 file_disk_space_used(const char *path);
+
+/**
+ * check if enough disk space is available on underlying file system of the corresponding
+ * file or directory at path.
+ * @param path The file name or directory name
+ * @param required The required disk space
+ * @param threshold Percentage of space which should be keept free; value in the range [0,1]
+ * @return true if enough space is available, false otherwise
+ */
+bool
+file_disk_space_available(const char *path, off_t required, float threshold);
 
 #endif /* FILE_H */

--- a/daemon/mount.c
+++ b/daemon/mount.c
@@ -152,13 +152,16 @@ mount_get_disk_usage_container(const mount_t *mnt)
 	for (size_t i = 0; i < count; i++) {
 		mount_entry_t *entry = mount_get_entry(mnt, i);
 		ASSERT(entry);
+		uint64_t image_size = mount_entry_get_size(entry); // MB
+		image_size *= 1024 * 1024;			   // Byte
+		ASSERT(entry);
 		switch (entry->type) {
 		case MOUNT_TYPE_OVERLAY_RW:
 		case MOUNT_TYPE_EMPTY: {
 			// meta.img
 			if (disk_usage <=
-			    (UINT64_MAX - entry->image_size * MOUNT_DM_INTEGRITY_META_FACTOR)) {
-				disk_usage += entry->image_size * MOUNT_DM_INTEGRITY_META_FACTOR;
+			    (UINT64_MAX - image_size * MOUNT_DM_INTEGRITY_META_FACTOR)) {
+				disk_usage += image_size * MOUNT_DM_INTEGRITY_META_FACTOR;
 			} else {
 				ERROR("Overflow detected");
 				return -1;
@@ -167,8 +170,8 @@ mount_get_disk_usage_container(const mount_t *mnt)
 		case MOUNT_TYPE_DEVICE:
 		case MOUNT_TYPE_DEVICE_RW:
 		case MOUNT_TYPE_COPY: {
-			if (disk_usage <= (UINT64_MAX - entry->image_size)) {
-				disk_usage += entry->image_size;
+			if (disk_usage <= (UINT64_MAX - image_size)) {
+				disk_usage += image_size;
 			} else {
 				ERROR("Overflow detected");
 				return -1;
@@ -198,11 +201,14 @@ mount_get_disk_usage_guestos(const mount_t *mnt)
 	for (size_t i = 0; i < count; i++) {
 		mount_entry_t *entry = mount_get_entry(mnt, i);
 		ASSERT(entry);
+		uint64_t image_size = mount_entry_get_size(entry); // MB
+		image_size *= 1024 * 1024;			   // Byte
+		ASSERT(entry);
 		switch (entry->type) {
 		case MOUNT_TYPE_SHARED:
 		case MOUNT_TYPE_COPY: {
-			if (disk_usage <= (UINT64_MAX - entry->image_size)) {
-				disk_usage += entry->image_size;
+			if (disk_usage <= (UINT64_MAX - image_size)) {
+				disk_usage += image_size;
 			} else {
 				ERROR("Overflow detected");
 				return -1;


### PR DESCRIPTION
This commit adds a disk space check to the container config update routine in order to prevent the loading of new configs which would allocate more disk space for a container than available.