### PR TITLE
scd/scd: Fixed hw_serial in common name of device.csr

### DIFF
--- a/scd/scd.c
+++ b/scd/scd.c
@@ -207,7 +207,7 @@ provisioning_mode()
 				hw_serial = mem_strdup("0000");
 
 			if (file_exists(DMI_PRODUCT_NAME))
-				hw_serial = file_read_new(DMI_PRODUCT_NAME, 512);
+				hw_name = file_read_new(DMI_PRODUCT_NAME, 512);
 			if (!hw_name)
 				hw_name = mem_strdup("generic");
 


### PR DESCRIPTION
Accidentialy hw_serial was set by HARDWARE_NAME instead of HARDWARE_SERIAL and hw_name was set to "generic" in any case. This is fixed now.

Fixes: 8adb459f10b3 ("scd/scd: Fixed common_name in device.csr generation")