### PR TITLE
Increase OS download blocksize

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -147,7 +147,7 @@ file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, o
 		return -1;
 	}
 
-	buf = alloca(bs); // TODO: use mem_new for big bs...
+	buf = mem_alloc0(bs);
 
 	ret = lseek(out_fd, seek * bs, SEEK_SET);
 	if (ret < 0) {
@@ -159,6 +159,10 @@ file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, o
 		ssize_t len;
 
 		len = read(in_fd, buf, bs);
+
+		if (0 == (i % 1024))
+			DEBUG("Copied %ld bytes from %s to %s", MUL_WITH_OVERFLOW_CHECK(bs, i),
+			      in_file, out_file);
 
 		if (len == 0) {
 			goto out;
@@ -178,6 +182,8 @@ file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, o
 out:
 	close(out_fd);
 	close(in_fd);
+	mem_free(buf);
+
 	return ret;
 }
 

--- a/daemon/download.c
+++ b/daemon/download.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 
 #define WGET_PATH "wget"
+#define DL_COPY_BUF_SIZE sysconf(_SC_PAGESIZE)
 
 struct download {
 	char *url;
@@ -129,7 +130,7 @@ download_start(download_t *dl)
 		if (do_file_copy) {
 			char *local_dl_src = dl->url + 7;
 			INFO("Copying file from %s -> %s", local_dl_src, dl->file);
-			int ret = file_copy(local_dl_src, dl->file, -1, 512, 0);
+			int ret = file_copy(local_dl_src, dl->file, -1, DL_COPY_BUF_SIZE, 0);
 			if (ret < 0)
 				ERROR("Failed retrieving '%s'!", dl->url);
 			_exit(ret);


### PR DESCRIPTION
This PR increaes the block size used for OS download operations. Also, a heap allocated buffer is now used to perform the copy operation.