### PR TITLE
common/ssl_util: asan fixes

### DIFF
--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -475,10 +475,10 @@ ssl_mkreq(EVP_PKEY *pkeyp, const char *common_name, const char *uid, UNUSED bool
 		goto error;
 	}
 
-	// free'd when X509_req is free'd
 	char *uri_uuid = mem_printf("URI:UUID:%s", uid);
 	if (add_ext_req(exts, NID_subject_alt_name, uri_uuid) != 0) {
 		ERROR("Error setting CSR extension (NID_subject_alt_name)");
+		mem_free0(uri_uuid);
 		goto error;
 	}
 
@@ -505,6 +505,7 @@ ssl_mkreq(EVP_PKEY *pkeyp, const char *common_name, const char *uid, UNUSED bool
 
 	DEBUG("Certificate request signed");
 
+	mem_free0(uri_uuid);
 	return req;
 
 error:

--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -159,8 +159,8 @@ ssl_init(bool use_tpm, void *tpm2d_primary_storage_key_pw)
 	//	ERROR("PRNG has not been seeded with enough data");
 	return 0;
 error:
-	ENGINE_free(tpm_engine);
 	ENGINE_finish(tpm_engine);
+	ENGINE_free(tpm_engine);
 	tpm_engine = NULL;
 	return -1;
 }
@@ -169,8 +169,8 @@ void
 ssl_free(void)
 {
 	if (tpm_engine) {
-		ENGINE_free(tpm_engine);
 		ENGINE_finish(tpm_engine);
+		ENGINE_free(tpm_engine);
 		tpm_engine = NULL;
 	}
 }

--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -1716,6 +1716,8 @@ error:
 		EVP_PKEY_free(key_evp_pub);
 	if (ext_stack)
 		sk_X509_EXTENSION_pop_free(ext_stack, X509_EXTENSION_free);
+	if (cert_name)
+		X509_NAME_free(cert_name);
 	return ret;
 }
 

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -86,6 +86,10 @@ static void
 scd_sigterm_cb(UNUSED int signum, UNUSED event_signal_t *sig, UNUSED void *data)
 {
 	INFO("Received SIGTERM..");
+	if (scd_logfile_p) {
+		logf_unregister(scd_logfile_handler);
+		logf_file_close(scd_logfile_p);
+	}
 	exit(0);
 }
 
@@ -276,6 +280,8 @@ provisioning_mode()
 
 	// we now have anything for a clean startup so just die and let us be restarted by init
 	if (need_initialization) {
+		logf_unregister(scd_logfile_handler);
+		logf_file_close(scd_logfile_p);
 		exit(0);
 	}
 

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -100,16 +100,16 @@ is_softtoken(const char *path, const char *file, UNUSED void *data)
 
 	// regular file
 	if (!file_is_regular(location))
-		return 0;
+		goto out;
 	// with fixed extesion
 	if (!(ext = file_get_extension(file)))
-		return 0;
+		goto out;
 	if (!strncmp(ext, TOKEN_DEFAULT_EXT, strlen(TOKEN_DEFAULT_EXT))) {
 		DEBUG("Found token file: %s", location);
 		mem_free0(location);
 		return 1;
 	}
-
+out:
 	mem_free0(location);
 	return 0;
 }


### PR DESCRIPTION
This PR fix the following asan log:

================================================================= ==229==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 46 byte(s) in 1 object(s) allocated from:
    #0 0x7fa24ee4ea2a in __interceptor_malloc [..]/gcc-11.4.0/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7fa24ec1f236 in __vasprintf_internal [..]/glibc/2.35-r0/git/libio/vasprintf.c:71
    #2 0x7ffcc3f74897  ([stack]+0x20897)

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fa24ee4ea2a in __interceptor_malloc [..]/gcc-11.4.0/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7fa24e8afc78 in CRYPTO_malloc [..]/openssl-3.0.15/crypto/mem.c:196

Indirect leak of 575 byte(s) in 17 object(s) allocated from:
    #0 0x7fa24ee4ea2a in __interceptor_malloc [..]/gcc-11.4.0/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7fa24e8afc78 in CRYPTO_malloc [..]/openssl-3.0.15/crypto/mem.c:196

SUMMARY: AddressSanitizer: 661 byte(s) leaked in 19 allocation(s).