### PR TITLE
daemon/c_seccomp/sysinfo: deactivate TRACING logs

### DIFF
--- a/daemon/c_seccomp/sysinfo.c
+++ b/daemon/c_seccomp/sysinfo.c
@@ -49,8 +49,8 @@
 
 #define CGROUPS_FOLDER "/sys/fs/cgroup"
 
-#undef LOGF_LOG_MIN_PRIO
-#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
 /*
  *  According to man sysinfo(2) the sysinfo struct looks like this:


### PR DESCRIPTION
During development of sysinfo emulation the TRACING output was activated. This was accidentally committed to the mainline feature in commit dd7e20d0bc54 "daemon/c_seccomp: introduce sysinfo() emulation". Just deactivate this now.

Fixes: dd7e20d0bc54 ("daemon/c_seccomp: introduce sysinfo() emulation")