### PR TITLE
daemon/audit: properly check return value of fread() + seccomp log verbosity

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -161,7 +161,7 @@ file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, o
 		len = read(in_fd, buf, bs);
 
 		if (0 == (i % 1024))
-			DEBUG("Copied %ld bytes from %s to %s", MUL_WITH_OVERFLOW_CHECK(bs, i),
+			TRACE("Copied %ld bytes from %s to %s", MUL_WITH_OVERFLOW_CHECK(bs, i),
 			      in_file, out_file);
 
 		if (len == 0) {

--- a/common/ns.c
+++ b/common/ns.c
@@ -159,7 +159,7 @@ do_join_namespace(const char *namespace, const int pid)
 
 	current_namespace_id[len] = 0;
 
-	DEBUG("Joining namespace with identifier %s, current namespace identifier is %s",
+	TRACE("Joining namespace with identifier %s, current namespace identifier is %s",
 	      target_namespace_id, current_namespace_id);
 
 	if (-1 == (ns_fd = open(target_namespace_path, O_RDONLY))) {
@@ -271,7 +271,7 @@ namespace_exec(pid_t namespace_pid, const int namespaces, int uid, int cap,
 	} else {
 		int status;
 
-		DEBUG("Waiting for namespace child %i to exit", pid);
+		TRACE("Waiting for namespace child %i to exit", pid);
 		if (proc_waitpid(pid, &status, 0) != pid) {
 			if (!WIFEXITED(status))
 				ERROR_ERRNO("Namespaced child %d did not exit cleanly", pid);

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -753,9 +753,6 @@ audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT com
 		}
 		TRACE("Logging audit message %s", record_text ? record_text : "");
 		mem_free0(record_text);
-	} else {
-		DEBUG("Logging %s for component %s", audit_category_to_string(category),
-		      audit_component_to_string(component));
 	}
 
 	ret = audit_record_log(audit_get_log_container(uuid), record);

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -46,6 +46,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <sys/file.h>
+#include <stdio.h>
 #include <time.h>
 #include <linux/audit.h>
 #include <inttypes.h>
@@ -331,8 +332,11 @@ audit_record_from_textfile_new(const char *filename, bool purge)
 		}
 
 		rewind(file);
-		if (fread(buf, sizeof(char), size, file)) {
-			ERROR("Failed to read audit log file into memory");
+		size_t read_len;
+		if ((size_t)size != (read_len = fread(buf, sizeof(char), size, file))) {
+			ERROR("Failed to read audit log file into memory read %zu "
+			      "expected %zd, [eof: %d, ferror: %d]",
+			      read_len, size, feof(file), ferror(file));
 			goto out;
 		}
 

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -392,14 +392,10 @@ audit_write_file(const uuid_t *uuid, const AuditRecord *msg)
 	int audit_file_lock = -1;
 	int fd = -1;
 
-	char *dir = mem_printf("%s/audit", AUDIT_LOGDIR);
-
-	if (!file_is_dir(dir) && dir_mkdir_p(dir, 0600)) {
+	if (!file_is_dir(AUDIT_LOGDIR) && dir_mkdir_p(AUDIT_LOGDIR, 0600)) {
 		ERROR("Failed to create logdir");
-		mem_free0(dir);
 		return -1;
 	}
-	mem_free0(dir);
 
 	char *file = audit_log_file_new(uuid_string(uuid));
 

--- a/daemon/c_seccomp/seccomp.c
+++ b/daemon/c_seccomp/seccomp.c
@@ -485,7 +485,7 @@ c_seccomp_handle_notify(int fd, unsigned events, UNUSED event_io_t *io, void *da
 				strerror(errno));
 		ERROR_ERRNO("Failed to send seccomp notify response");
 	} else {
-		DEBUG("Successfully handled seccomp notification");
+		TRACE("Successfully handled seccomp notification");
 	}
 
 	mem_free(syscall_str);

--- a/daemon/c_seccomp/sysinfo.c
+++ b/daemon/c_seccomp/sysinfo.c
@@ -274,7 +274,7 @@ c_seccomp_do_sysinfo_fork(const void *data)
 	}
 
 	// initialize struct sysinfo with host values
-	DEBUG("Executing sysinfo in namespaces of container");
+	TRACE("Executing sysinfo in namespaces of container");
 	if (-1 == sysinfo(sysinfo_params->info)) {
 		ERROR_ERRNO("Failed to execute sysinfo");
 		return -1;
@@ -378,10 +378,10 @@ c_seccomp_emulate_sysinfo(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	int ret_sysinfo = 0;
 	struct sysinfo *info;
 
-	DEBUG("Got sysinfo, struct sysinfo *: %p", (void *)req->data.args[0]);
+	TRACE("Got sysinfo, struct sysinfo *: %p", (void *)req->data.args[0]);
 	info = mem_new0(struct sysinfo, 1);
 
-	DEBUG("Executing sysinfo on behalf of container");
+	TRACE("Executing sysinfo on behalf of container");
 	// Join all namespaces but pidns; thus, the helper process won't show up inside the container
 	// Uptime will then already be correctly handled by time namespace
 	struct sysinfo_fork_data sysinfo_params = { .seccomp = seccomp,
@@ -394,7 +394,7 @@ c_seccomp_emulate_sysinfo(c_seccomp_t *seccomp, struct seccomp_notif *req,
 		goto out;
 	}
 
-	DEBUG("sysinfo returned %d", ret_sysinfo);
+	TRACE("sysinfo returned %d", ret_sysinfo);
 
 	// prepare answer
 	resp->id = req->id;

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -1729,13 +1729,13 @@ control_cb_accept(int fd, unsigned events, event_io_t *io, void *data)
 		WARN("Could not accept control connection");
 		return;
 	}
-	DEBUG("Accepted control connection %d", cfd);
+	TRACE("Accepted control connection %d", cfd);
 
 	fd_make_non_blocking(cfd);
 
 	event_io_t *event =
 		event_io_new(cfd, EVENT_IO_READ, control_cb_recv_message_local, control);
-	DEBUG("local control client connected on fd=%d", cfd);
+	TRACE("local control client connected on fd=%d", cfd);
 
 	event_add_io(event);
 }


### PR DESCRIPTION
In function audit_record_from_textfile_new() the return value of fread() was checked against non-zero as error indicator. This was wrong. We now check if the return value has the expected amount of bytes to be read.

Fixes: 526d6ccf99d3 ("daemon/audit: locking of audit log file")