### PR TITLE
daemon/common: Log verbosity reduction

### DIFF
--- a/common/event.c
+++ b/common/event.c
@@ -285,7 +285,7 @@ event_epoll_fd(int reset)
 
 		ASSERT(fd >= 0);
 
-		DEBUG("epoll_create returned %d", fd);
+		TRACE_ERRNO("epoll_create returned %d", fd);
 
 		// set close-on-exec flag
 		int oldflags;

--- a/common/macro.h
+++ b/common/macro.h
@@ -111,35 +111,35 @@
 #define IF_NULL_RETURN_TRACE(ptr)                                                                  \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			TRACE("Check failed: pointer `%s' is NULL", #ptr);                         \
+			TRACE("Check matched: pointer `%s' is NULL", #ptr);                        \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_DEBUG(ptr)                                                                  \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			DEBUG("Check failed: pointer `%s' is NULL", #ptr);                         \
+			DEBUG("Check matched: pointer `%s' is NULL", #ptr);                        \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_INFO(ptr)                                                                   \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			INFO("Check failed: pointer `%s' is NULL", #ptr);                          \
+			INFO("Check matched: pointer `%s' is NULL", #ptr);                         \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_WARN(ptr)                                                                   \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			WARN("Check failed: pointer `%s' is NULL", #ptr);                          \
+			WARN("Check matched: pointer `%s' is NULL", #ptr);                         \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_ERROR(ptr)                                                                  \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			ERROR("Check failed: pointer `%s' is NULL", #ptr);                         \
+			ERROR("Check matched: pointer `%s' is NULL", #ptr);                        \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
@@ -147,35 +147,35 @@
 #define IF_NULL_RETVAL_TRACE(ptr, val)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			TRACE("Check failed: pointer `%s' is NULL", #ptr);                         \
+			TRACE("Check matched: pointer `%s' is NULL", #ptr);                        \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_DEBUG(ptr, val)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			DEBUG("Check failed: pointer `%s' is NULL", #ptr);                         \
+			DEBUG("Check matched: pointer `%s' is NULL", #ptr);                        \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_INFO(ptr, val)                                                              \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			INFO("Check failed: pointer `%s' is NULL", #ptr);                          \
+			INFO("Check matched: pointer `%s' is NULL", #ptr);                         \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_WARN(ptr, val)                                                              \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			WARN("Check failed: pointer `%s' is NULL", #ptr);                          \
+			WARN("Check matched: pointer `%s' is NULL", #ptr);                         \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_ERROR(ptr, val)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			ERROR("Check failed: pointer `%s' is NULL", #ptr);                         \
+			ERROR("Check matched: pointer `%s' is NULL", #ptr);                        \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
@@ -183,35 +183,35 @@
 #define IF_NULL_GOTO_TRACE(ptr, label)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			TRACE("Check failed: pointer `%s' is NULL", #ptr);                         \
+			TRACE("Check matched: pointer `%s' is NULL", #ptr);                        \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_DEBUG(ptr, label)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			DEBUG("Check failed: pointer `%s' is NULL", #ptr);                         \
+			DEBUG("Check matched: pointer `%s' is NULL", #ptr);                        \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_INFO(ptr, label)                                                              \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			INFO("Check failed: pointer `%s' is NULL", #ptr);                          \
+			INFO("Check matched: pointer `%s' is NULL", #ptr);                         \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_WARN(ptr, label)                                                              \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			WARN("Check failed: pointer `%s' is NULL", #ptr);                          \
+			WARN("Check matched: pointer `%s' is NULL", #ptr);                         \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_ERROR(ptr, label)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			ERROR("Check failed: pointer `%s' is NULL", #ptr);                         \
+			ERROR("Check matched: pointer `%s' is NULL", #ptr);                        \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
@@ -219,35 +219,35 @@
 #define IF_TRUE_RETURN_TRACE(expr)                                                                 \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			TRACE("Check failed: expression `%s' is true", #expr);                     \
+			TRACE("Check matched: expression `%s' is true", #expr);                    \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_DEBUG(expr)                                                                 \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			DEBUG("Check failed: expression `%s' is true", #expr);                     \
+			DEBUG("Check matched: expression `%s' is true", #expr);                    \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_INFO(expr)                                                                  \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			INFO("Check failed: expression `%s' is true", #expr);                      \
+			INFO("Check matched: expression `%s' is true", #expr);                     \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_WARN(expr)                                                                  \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			WARN("Check failed: expression `%s' is true", #expr);                      \
+			WARN("Check matched: expression `%s' is true", #expr);                     \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_ERROR(expr)                                                                 \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			ERROR("Check failed: expression `%s' is true", #expr);                     \
+			ERROR("Check matched: expression `%s' is true", #expr);                    \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
@@ -255,35 +255,35 @@
 #define IF_TRUE_RETVAL_TRACE(expr, val)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			TRACE("Check failed: expression `%s' is true", #expr);                     \
+			TRACE("Check matched: expression `%s' is true", #expr);                    \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_DEBUG(expr, val)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			DEBUG("Check failed: expression `%s' is true", #expr);                     \
+			DEBUG("Check matched: expression `%s' is true", #expr);                    \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_INFO(expr, val)                                                             \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			INFO("Check failed: expression `%s' is true", #expr);                      \
+			INFO("Check matched: expression `%s' is true", #expr);                     \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_WARN(expr, val)                                                             \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			WARN("Check failed: expression `%s' is true", #expr);                      \
+			WARN("Check matched: expression `%s' is true", #expr);                     \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_ERROR(expr, val)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			ERROR("Check failed: expression `%s' is true", #expr);                     \
+			ERROR("Check matched: expression `%s' is true", #expr);                    \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
@@ -291,35 +291,35 @@
 #define IF_TRUE_GOTO_TRACE(expr, label)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			TRACE("Check failed: expression `%s' is true", #expr);                     \
+			TRACE("Check matched: expression `%s' is true", #expr);                    \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_DEBUG(expr, label)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			DEBUG("Check failed: expression `%s' is true", #expr);                     \
+			DEBUG("Check matched: expression `%s' is true", #expr);                    \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_INFO(expr, label)                                                             \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			INFO("Check failed: expression `%s' is true", #expr);                      \
+			INFO("Check matched: expression `%s' is true", #expr);                     \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_WARN(expr, label)                                                             \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			WARN("Check failed: expression `%s' is true", #expr);                      \
+			WARN("Check matched: expression `%s' is true", #expr);                     \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_ERROR(expr, label)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			ERROR("Check failed: expression `%s' is true", #expr);                     \
+			ERROR("Check matched: expression `%s' is true", #expr);                    \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
@@ -327,35 +327,35 @@
 #define IF_FALSE_RETURN_TRACE(expr)                                                                \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			TRACE("Check failed: expression `%s' is false", #expr);                    \
+			TRACE("Check matched: expression `%s' is false", #expr);                   \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_DEBUG(expr)                                                                \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			DEBUG("Check failed: expression `%s' is false", #expr);                    \
+			DEBUG("Check matched: expression `%s' is false", #expr);                   \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_INFO(expr)                                                                 \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			INFO("Check failed: expression `%s' is false", #expr);                     \
+			INFO("Check matched: expression `%s' is false", #expr);                    \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_WARN(expr)                                                                 \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			WARN("Check failed: expression `%s' is false", #expr);                     \
+			WARN("Check matched: expression `%s' is false", #expr);                    \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_ERROR(expr)                                                                \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			ERROR("Check failed: expression `%s' is false", #expr);                    \
+			ERROR("Check matched: expression `%s' is false", #expr);                   \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
@@ -363,35 +363,35 @@
 #define IF_FALSE_RETVAL_TRACE(expr, val)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			TRACE("Check failed: expression `%s' is false", #expr);                    \
+			TRACE("Check matched: expression `%s' is false", #expr);                   \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_DEBUG(expr, val)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			DEBUG("Check failed: expression `%s' is false", #expr);                    \
+			DEBUG("Check matched: expression `%s' is false", #expr);                   \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_INFO(expr, val)                                                            \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			INFO("Check failed: expression `%s' is false", #expr);                     \
+			INFO("Check matched: expression `%s' is false", #expr);                    \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_WARN(expr, val)                                                            \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			WARN("Check failed: expression `%s' is false", #expr);                     \
+			WARN("Check matched: expression `%s' is false", #expr);                    \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_ERROR(expr, val)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			ERROR("Check failed: expression `%s' is false", #expr);                    \
+			ERROR("Check matched: expression `%s' is false", #expr);                   \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
@@ -399,35 +399,35 @@
 #define IF_FALSE_GOTO_TRACE(expr, label)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			TRACE("Check failed: expression `%s' is false", #expr);                    \
+			TRACE("Check matched: expression `%s' is false", #expr);                   \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_DEBUG(expr, label)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			DEBUG("Check failed: expression `%s' is false", #expr);                    \
+			DEBUG("Check matched: expression `%s' is false", #expr);                   \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_INFO(expr, label)                                                            \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			INFO("Check failed: expression `%s' is false", #expr);                     \
+			INFO("Check matched: expression `%s' is false", #expr);                    \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_WARN(expr, label)                                                            \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			WARN("Check failed: expression `%s' is false", #expr);                     \
+			WARN("Check matched: expression `%s' is false", #expr);                    \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_ERROR(expr, label)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			ERROR("Check failed: expression `%s' is false", #expr);                    \
+			ERROR("Check matched: expression `%s' is false", #expr);                   \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
@@ -435,35 +435,35 @@
 #define IF_NULL_RETURN_TRACE_ERRNO(ptr)                                                            \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			TRACE_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			TRACE_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_DEBUG_ERRNO(ptr)                                                            \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			DEBUG_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			DEBUG_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_INFO_ERRNO(ptr)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			INFO_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                    \
+			INFO_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                   \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_WARN_ERRNO(ptr)                                                             \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			WARN_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                    \
+			WARN_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                   \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETURN_ERROR_ERRNO(ptr)                                                            \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			ERROR_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			ERROR_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
@@ -471,35 +471,35 @@
 #define IF_NULL_RETVAL_TRACE_ERRNO(ptr, val)                                                       \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			TRACE_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			TRACE_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_DEBUG_ERRNO(ptr, val)                                                       \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			DEBUG_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			DEBUG_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_INFO_ERRNO(ptr, val)                                                        \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			INFO_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                    \
+			INFO_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                   \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_WARN_ERRNO(ptr, val)                                                        \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			WARN_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                    \
+			WARN_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                   \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_RETVAL_ERROR_ERRNO(ptr, val)                                                       \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			ERROR_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			ERROR_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
@@ -507,35 +507,35 @@
 #define IF_NULL_GOTO_TRACE_ERRNO(ptr, label)                                                       \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			TRACE_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			TRACE_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_DEBUG_ERRNO(ptr, label)                                                       \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			DEBUG_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			DEBUG_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_INFO_ERRNO(ptr, label)                                                        \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			INFO_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                    \
+			INFO_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                   \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_WARN_ERRNO(ptr, label)                                                        \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			WARN_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                    \
+			WARN_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                   \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_NULL_GOTO_ERROR_ERRNO(ptr, label)                                                       \
 	do {                                                                                       \
 		if ((ptr) == NULL) {                                                               \
-			ERROR_ERRNO("Check failed: pointer `%s' is NULL", #ptr);                   \
+			ERROR_ERRNO("Check matched: pointer `%s' is NULL", #ptr);                  \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
@@ -543,35 +543,35 @@
 #define IF_TRUE_RETURN_TRACE_ERRNO(expr)                                                           \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			TRACE_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			TRACE_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_DEBUG_ERRNO(expr)                                                           \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			DEBUG_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			DEBUG_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_INFO_ERRNO(expr)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			INFO_ERRNO("Check failed: expression `%s' is true", #expr);                \
+			INFO_ERRNO("Check matched: expression `%s' is true", #expr);               \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_WARN_ERRNO(expr)                                                            \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			WARN_ERRNO("Check failed: expression `%s' is true", #expr);                \
+			WARN_ERRNO("Check matched: expression `%s' is true", #expr);               \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETURN_ERROR_ERRNO(expr)                                                           \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			ERROR_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			ERROR_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
@@ -579,35 +579,35 @@
 #define IF_TRUE_RETVAL_TRACE_ERRNO(expr, val)                                                      \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			TRACE_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			TRACE_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_DEBUG_ERRNO(expr, val)                                                      \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			DEBUG_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			DEBUG_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_INFO_ERRNO(expr, val)                                                       \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			INFO_ERRNO("Check failed: expression `%s' is true", #expr);                \
+			INFO_ERRNO("Check matched: expression `%s' is true", #expr);               \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_WARN_ERRNO(expr, val)                                                       \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			WARN_ERRNO("Check failed: expression `%s' is true", #expr);                \
+			WARN_ERRNO("Check matched: expression `%s' is true", #expr);               \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_RETVAL_ERROR_ERRNO(expr, val)                                                      \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			ERROR_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			ERROR_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
@@ -615,35 +615,35 @@
 #define IF_TRUE_GOTO_TRACE_ERRNO(expr, label)                                                      \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			TRACE_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			TRACE_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_DEBUG_ERRNO(expr, label)                                                      \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			DEBUG_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			DEBUG_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_INFO_ERRNO(expr, label)                                                       \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			INFO_ERRNO("Check failed: expression `%s' is true", #expr);                \
+			INFO_ERRNO("Check matched: expression `%s' is true", #expr);               \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_WARN_ERRNO(expr, label)                                                       \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			WARN_ERRNO("Check failed: expression `%s' is true", #expr);                \
+			WARN_ERRNO("Check matched: expression `%s' is true", #expr);               \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_TRUE_GOTO_ERROR_ERRNO(expr, label)                                                      \
 	do {                                                                                       \
 		if (expr) {                                                                        \
-			ERROR_ERRNO("Check failed: expression `%s' is true", #expr);               \
+			ERROR_ERRNO("Check matched: expression `%s' is true", #expr);              \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
@@ -651,35 +651,35 @@
 #define IF_FALSE_RETURN_TRACE_ERRNO(expr)                                                          \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			TRACE_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			TRACE_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_DEBUG_ERRNO(expr)                                                          \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			DEBUG_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			DEBUG_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_INFO_ERRNO(expr)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			INFO_ERRNO("Check failed: expression `%s' is false", #expr);               \
+			INFO_ERRNO("Check matched: expression `%s' is false", #expr);              \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_WARN_ERRNO(expr)                                                           \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			WARN_ERRNO("Check failed: expression `%s' is false", #expr);               \
+			WARN_ERRNO("Check matched: expression `%s' is false", #expr);              \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETURN_ERROR_ERRNO(expr)                                                          \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			ERROR_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			ERROR_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			return;                                                                    \
 		}                                                                                  \
 	} while (0)
@@ -687,35 +687,35 @@
 #define IF_FALSE_RETVAL_TRACE_ERRNO(expr, val)                                                     \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			TRACE_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			TRACE_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_DEBUG_ERRNO(expr, val)                                                     \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			DEBUG_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			DEBUG_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_INFO_ERRNO(expr, val)                                                      \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			INFO_ERRNO("Check failed: expression `%s' is false", #expr);               \
+			INFO_ERRNO("Check matched: expression `%s' is false", #expr);              \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_WARN_ERRNO(expr, val)                                                      \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			WARN_ERRNO("Check failed: expression `%s' is false", #expr);               \
+			WARN_ERRNO("Check matched: expression `%s' is false", #expr);              \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_RETVAL_ERROR_ERRNO(expr, val)                                                     \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			ERROR_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			ERROR_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			return (val);                                                              \
 		}                                                                                  \
 	} while (0)
@@ -723,35 +723,35 @@
 #define IF_FALSE_GOTO_TRACE_ERRNO(expr, label)                                                     \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			TRACE_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			TRACE_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_DEBUG_ERRNO(expr, label)                                                     \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			DEBUG_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			DEBUG_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_INFO_ERRNO(expr, label)                                                      \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			INFO_ERRNO("Check failed: expression `%s' is false", #expr);               \
+			INFO_ERRNO("Check matched: expression `%s' is false", #expr);              \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_WARN_ERRNO(expr, label)                                                      \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			WARN_ERRNO("Check failed: expression `%s' is false", #expr);               \
+			WARN_ERRNO("Check matched: expression `%s' is false", #expr);              \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)
 #define IF_FALSE_GOTO_ERROR_ERRNO(expr, label)                                                     \
 	do {                                                                                       \
 		if (!(expr)) {                                                                     \
-			ERROR_ERRNO("Check failed: expression `%s' is false", #expr);              \
+			ERROR_ERRNO("Check matched: expression `%s' is false", #expr);             \
 			goto label;                                                                \
 		}                                                                                  \
 	} while (0)

--- a/common/network.c
+++ b/common/network.c
@@ -21,7 +21,7 @@
  * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
-#define LOGF_LOG_MIN_PRIO 2
+//#define LOGF_LOG_MIN_PRIO 2
 #define _GNU_SOURCE
 
 #include "network.h"

--- a/common/nl.c
+++ b/common/nl.c
@@ -636,7 +636,7 @@ nl_eval_ack(const nl_sock_t *nl, UNUSED uint32_t seq)
 					ERROR_ERRNO("ACK reports an error!");
 					break;
 				} else {
-					DEBUG("ACK successfully found");
+					TRACE("ACK successfully found");
 					mem_free0(buf);
 					return 0;
 				}
@@ -667,7 +667,7 @@ nl_msg_send_kernel_verify(const nl_sock_t *nl_sock, const nl_msg_t *req)
 	if (nl_msg_send_kernel(nl_sock, req) < 0)
 		return -1;
 
-	DEBUG("Netlink message sent, waiting for ACK");
+	TRACE("Netlink message sent, waiting for ACK");
 
 	/* Wait for and receive acknowledgment */
 	return nl_eval_ack(nl_sock, req->nlmsghdr.nlmsg_seq);

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -131,7 +131,7 @@ protobuf_recv_message_packed_new(int fd, ssize_t *ret_len)
 
 	if (0 == bytes_read ||
 	    (-1 == bytes_read && ECONNRESET == errno)) { // EOF / remote end closed the connection
-		DEBUG("client on fd %d closed connection.", fd);
+		TRACE("client on fd %d closed connection.", fd);
 		*ret_len = -2;
 		return NULL;
 	}

--- a/common/verity.c
+++ b/common/verity.c
@@ -21,7 +21,7 @@
  * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
-#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
 #include <stdio.h>
 #include <stdint.h>

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -324,7 +324,7 @@ audit_record_from_textfile_new(const char *filename, bool purge)
 	if (purge) {
 		// delete record from file
 		if (read + strlen(AUDIT_DELIMITER) == (size_t)size) {
-			DEBUG("Audit log empty, removing file");
+			TRACE("Audit log empty, removing file");
 			if (-1 == unlink(filename)) {
 				ERROR_ERRNO("Failed to remove audit log file");
 			}
@@ -571,7 +571,7 @@ audit_send_next_stored(const container_t *c)
 	TRACE("send_next_stored log file: %s", file);
 
 	if (!file_exists(file)) {
-		DEBUG("Sent all stored audit messages");
+		TRACE("Sent all stored audit messages");
 		mem_free0(file);
 
 		if (0 > container_audit_notify_complete(c)) {
@@ -658,7 +658,7 @@ audit_record_log(container_t *c, AuditRecord *record)
 			goto out;
 		}
 	} else {
-		ERROR("No audit logging container available, will log to file %s",
+		TRACE("No audit logging container available, will log to file %s",
 		      AUDIT_DEFAULT_CONTAINER);
 		uuid_t *default_uuid = uuid_new(AUDIT_DEFAULT_CONTAINER);
 		if (0 != (ret = audit_write_file(default_uuid, record))) {

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -144,8 +144,8 @@ c_service_handle_received_message(c_service_t *service, int sock_client,
 		break;
 
 	case SERVICE_TO_CMLD_MESSAGE__CODE__AUDIT_ACK: {
-		INFO("Got ACK from Container %s",
-		     uuid_string(container_get_uuid(service->container)));
+		TRACE("Got ACK from Container %s",
+		      uuid_string(container_get_uuid(service->container)));
 
 		if (0 > audit_process_ack(service->container, message->audit_ack)) {
 			ERROR("Failed to process audit ACK from container %s",

--- a/daemon/c_smartcard.c
+++ b/daemon/c_smartcard.c
@@ -347,7 +347,7 @@ c_smartcard_cb_ctrl_container(int fd, unsigned events, event_io_t *io, void *dat
 				      container_get_name(smartcard->container), keyfile);
 				unsigned char key[TOKEN_MAX_WRAPPED_KEY_LEN];
 				int keylen = file_read(keyfile, (char *)key, sizeof(key));
-				DEBUG("Length of existing key: %d", keylen);
+				TRACE("Length of existing key: %d", keylen);
 				if (keylen < TOKEN_KEY_LEN) {
 					audit_log_event(container_get_uuid(smartcard->container),
 							FSA, CMLD, TOKEN_MGMT, "read-wrapped-key",
@@ -446,7 +446,7 @@ c_smartcard_cb_ctrl_container(int fd, unsigned events, event_io_t *io, void *dat
 		 */
 		case TOKEN_TO_DAEMON__CODE__UNWRAPPED_KEY: {
 			if (!msg->has_unwrapped_key) {
-				WARN("Expected derived key, but none was returned!");
+				ERROR("Expected derived key, but none was returned!");
 				audit_log_event(
 					container_get_uuid(smartcard->container), FSA, CMLD,
 					TOKEN_MGMT, "unwrap-container-key",
@@ -492,7 +492,7 @@ c_smartcard_cb_ctrl_container(int fd, unsigned events, event_io_t *io, void *dat
 					container_get_uuid(smartcard->container), FSA, CMLD,
 					TOKEN_MGMT, "wrap-key",
 					uuid_string(container_get_uuid(smartcard->container)), 0);
-				WARN("Expected wrapped key, but none was returned!");
+				ERROR("Expected wrapped key, but none was returned!");
 				c_smartcard_error(smartcard, CONTAINER_SMARTCARD_WRAPPING_ERROR);
 				done = true;
 				break;

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1599,7 +1599,7 @@ c_vol_start_child_early(void *volp)
 
 	return 0;
 error:
-	ERROR("Failed to execute star child early hook for c_vol");
+	ERROR("Failed to execute start child early hook for c_vol");
 	return -COMPARTMENT_ERROR_VOL;
 }
 

--- a/daemon/crypto.c
+++ b/daemon/crypto.c
@@ -59,7 +59,7 @@ crypto_send_recv_block(const DaemonToToken *out)
 		return NULL;
 	}
 
-	DEBUG("crypto_send_recv_block: connected to sock %d", sock);
+	TRACE("crypto_send_recv_block: connected to sock %d", sock);
 
 	if (protobuf_send_message(sock, (ProtobufCMessage *)out) < 0) {
 		ERROR("Failed to send message to scd on sock %d", sock);
@@ -373,7 +373,7 @@ crypto_send_msg(const DaemonToToken *out, crypto_callback_task_t *task)
 		return -1;
 	}
 
-	DEBUG("crypto_send_msg: connected to sock %d", sock);
+	TRACE("crypto_send_msg: connected to sock %d", sock);
 	event_io_t *event = event_io_new(sock, EVENT_IO_READ, crypto_cb, task);
 	event_add_io(event);
 
@@ -408,7 +408,7 @@ crypto_generic_send_msg(const DaemonToToken *out, int resp_fd)
 	int *fd = mem_new0(int, 1);
 	*fd = resp_fd;
 
-	DEBUG("crypto_generic_send_msg: connected to sock %d", sock);
+	TRACE("crypto_generic_send_msg: connected to sock %d", sock);
 	event_io_t *event = event_io_new(sock, EVENT_IO_READ, crypto_generic_cb, fd);
 	event_add_io(event);
 
@@ -686,14 +686,14 @@ crypto_match_hash(size_t hash_len, const char *expected_hash, const char *hash)
 	//TODO harden against hash algorithms with NULL bytes in digest
 	size_t len = strlen(expected_hash);
 	if (len != 2 * hash_len) {
-		ERROR("Invalid hash length %zu/2, expected %zu/2 bytes", len, 2 * hash_len);
+		TRACE("Invalid hash length %zu/2, expected %zu/2 bytes", len, 2 * hash_len);
 		return false;
 	}
 	if (strncasecmp(expected_hash, hash, len + 1)) {
 		DEBUG("Hash mismatch");
 		return false;
 	}
-	DEBUG("Hashes match");
+	TRACE("Hashes match");
 	return true;
 }
 


### PR DESCRIPTION
This commit adapts the logging verbosity of the cmld and libcommon logs. To this end, the log level of a number of messages ischanged from DEBUG to TRACE and overrides of the loglevel in common/network.c and common/verity.c are removed. Also, log messages of checks in common/macro.h are rephrased.