### PR TITLE
daemon/seccomp: disble emulation of sysinfo()

### DIFF
--- a/daemon/c_seccomp/seccomp.c
+++ b/daemon/c_seccomp/seccomp.c
@@ -241,7 +241,7 @@ c_seccomp_install_filter(c_seccomp_t *_seccomp)
 		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFCHR, 7, 0),
 		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFBLK, 6, 0),
 
-		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_sysinfo, 5, 0),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_sysinfo, 4, 0),
 
 		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_finit_module, 4, 0),
 


### PR DESCRIPTION
syscall emulation code currently makes trouble for some container payloads. Thus, just disbale it for now by jumping to instruction "BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)" in the syscal filter.