### PR TITLE
Xorg compat

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -33,6 +33,7 @@ CGROUP_V2 ?= y
 CGROUP_SOCKOPT ?= n
 SYSTEMD ?= n
 AUTOMOUNT ?= y
+XORG_COMPAT ?= n
 
 # Enable experimental not yet completed features for testing/debugging purpose only!
 CC_MODE_EXPERIMENTAL ?= n
@@ -178,6 +179,9 @@ ifeq ($(OCI),y)
     SRC_CMODULES += c_oci.c
 endif
 
+ifeq ($(XORG_COMPAT),y)
+    SRC_CMODULES += c_xorg_compat.c
+endif
 
 ifeq ($(CC_MODE),y)
 protobuf: container.proto control.proto guestos.proto device.proto scd.proto common/audit.proto c_service.proto

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -33,7 +33,7 @@ CGROUP_V2 ?= y
 CGROUP_SOCKOPT ?= n
 SYSTEMD ?= n
 AUTOMOUNT ?= y
-XORG_COMPAT ?= n
+XORG_COMPAT ?= y
 
 # Enable experimental not yet completed features for testing/debugging purpose only!
 CC_MODE_EXPERIMENTAL ?= n

--- a/daemon/c_xorg_compat.c
+++ b/daemon/c_xorg_compat.c
@@ -1,0 +1,132 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2024 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+  * @file c_xorg_compat.c
+  *
+  * This module provdies compat funtionality for xorg on current kernel
+  * grater then version 6.9.
+  */
+
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+#define MOD_NAME "c_xorg_compat"
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "compartment.h"
+
+#include <limits.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <unistd.h>
+
+/******************************************************************************/
+
+#define SYS_DIR "/sys/class/graphics"
+
+static int
+c_xorg_compat_start_child(UNUSED void *unused)
+{
+	char link[PATH_MAX] = { 0 };
+	if (readlink(SYS_DIR "/fb0", link, PATH_MAX) < 0) {
+		WARN_ERRNO("Readlink of " SYS_DIR "/fb0 failed, no compat mode will be setup.");
+		return 0;
+	}
+
+	IF_NULL_RETVAL(strstr(link, "devices/pci"), 0);
+
+	const char *fb_drv;
+	if (strstr(link, "efi-framebuffer"))
+		fb_drv = "efi";
+	else if (strstr(link, "vesa-framebuffer"))
+		fb_drv = "vesa";
+	else
+		fb_drv = NULL;
+
+	IF_NULL_RETVAL(fb_drv, 0);
+
+	if (mount("graphics", SYS_DIR, "tmpfs", MS_RELATIME | MS_NOSUID, NULL) < 0) {
+		ERROR_ERRNO("Could not mount " SYS_DIR);
+		goto err;
+	}
+
+	// restore fbcon link
+	const char *lnk_target = "../../devices/virtual/graphics/fbcon";
+	if (symlink(lnk_target, SYS_DIR "/fbcon")) {
+		WARN_ERRNO("Could not link %s to " SYS_DIR "/fcon in container", lnk_target);
+		goto err_mount;
+	}
+
+	// gen legacy fb0 link for platfrom drivers
+	char *fb_lnk_target =
+		mem_printf("../../bus/platform/devices/%s-framebuffer.0/graphics/fb0", fb_drv);
+	if (symlink(lnk_target, SYS_DIR "/fb0")) {
+		WARN_ERRNO("Could not link %s to " SYS_DIR "/fb0 in container", fb_lnk_target);
+		goto err_fb_lnk;
+	}
+
+	mem_free0(fb_lnk_target);
+	return 0;
+
+err_fb_lnk:
+	mem_free0(fb_lnk_target);
+err_mount:
+	if (umount(SYS_DIR))
+		WARN("Could not umount " SYS_DIR "!");
+err:
+	return -COMPARTMENT_ERROR;
+}
+
+static void
+c_xorg_compat_cleanup(UNUSED void *xorg_compatp, UNUSED bool is_rebooting)
+{
+	if (umount(SYS_DIR))
+		WARN("Could not umount " SYS_DIR " properly");
+}
+
+static compartment_module_t c_xorg_compat_module = {
+	.name = MOD_NAME,
+	.compartment_new = NULL,
+	.compartment_free = NULL,
+	.compartment_destroy = NULL,
+	.start_post_clone_early = NULL,
+	.start_child_early = NULL,
+	.start_pre_clone = NULL,
+	.start_post_clone = NULL,
+	.start_pre_exec = NULL,
+	.start_post_exec = NULL,
+	.start_child = c_xorg_compat_start_child,
+	.start_pre_exec_child = NULL,
+	.stop = NULL,
+	.cleanup = c_xorg_compat_cleanup,
+	.join_ns = NULL,
+	.flags = 0,
+};
+
+static void INIT
+c_xorg_compat_init(void)
+{
+	// register this module in compartment.c
+	compartment_register_module(&c_xorg_compat_module);
+}

--- a/daemon/cc_mode/container.proto
+++ b/daemon/cc_mode/container.proto
@@ -126,6 +126,9 @@ message ContainerConfig {
 	required ContainerTokenType token_type = 30 [ default = SOFT ];
 
 	optional bool usb_pin_entry = 31 [ default = false ];
+
+	// enable module to support legacy xorg server
+	optional bool enable_xorg_compat = 32 [ default = false ];
 }
 
 /**

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -407,6 +407,7 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 	char **allowed_devices;
 	char **assigned_devices;
 	const char *init;
+	bool enable_xorg_compat;
 	container_t *c = NULL;
 
 	if (!existing_uuid) {
@@ -526,11 +527,13 @@ cmld_container_new(const char *store_path, const uuid_t *existing_uuid, const ui
 
 	bool usb_pin_entry = container_config_get_usb_pin_entry(conf);
 
+	enable_xorg_compat = container_config_get_enable_xorg_compat(conf);
+
 	c = container_new(uuid, name, type, ns_usr, ns_net, os, config_filename, images_dir,
 			  ram_limit, cpus_allowed, color, allow_autostart, allow_system_time,
 			  dns_server, pnet_cfg_list, allowed_module_list, allowed_devices,
 			  assigned_devices, vnet_cfg_list, usbdev_list, init, init_argv, init_env,
-			  init_env_len, fifo_list, ttype, usb_pin_entry);
+			  init_env_len, fifo_list, ttype, usb_pin_entry, enable_xorg_compat);
 	if (c) {
 		// overwrite image sizes of mount table
 		container_config_fill_mount(conf, container_get_mnt(c));
@@ -1256,7 +1259,7 @@ cmld_init_c0(const char *path, const char *c0os)
 		container_new(c0_uuid, "c0", CONTAINER_TYPE_CONTAINER, false, c0_ns_net, c0_os,
 			      NULL, c0_images_folder, c0_ram_limit, NULL, 0xffffff00, false, false,
 			      cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL, NULL, init,
-			      init_argv, NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false);
+			      init_argv, NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false, false);
 
 	/* store c0 as first element of the cmld_containers_list */
 	cmld_containers_list = list_prepend(cmld_containers_list, new_c0);

--- a/daemon/compartment.h
+++ b/daemon/compartment.h
@@ -71,6 +71,7 @@ typedef struct compartment_extension compartment_extension_t;
 #define COMPARTMENT_FLAG_NS_IPC 0x0000000000000010
 #define COMPARTMENT_FLAG_SYSTEM_TIME 0x0000000000000020
 #define COMPARTMENT_FLAG_MODULE_LOAD 0x0000000000000040
+#define COMPARTMENT_FLAG_XORG_COMPAT 0x0000000000000080
 
 /**
  * Represents the current compartment state.

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -106,7 +106,7 @@ container_new(const uuid_t *uuid, const char *name, container_type_t type, bool 
 	      list_t *pnet_cfg_list, list_t *allowed_module_list, char **allowed_devices,
 	      char **assigned_devices, list_t *vnet_cfg_list, list_t *usbdev_list, const char *init,
 	      char **init_argv, char **init_env, size_t init_env_len, list_t *fifo_list,
-	      container_token_type_t ttype, bool usb_pin_entry)
+	      container_token_type_t ttype, bool usb_pin_entry, bool xorg_compat)
 {
 	container_t *container = mem_new0(container_t, 1);
 
@@ -174,10 +174,14 @@ container_new(const uuid_t *uuid, const char *name, container_type_t type, bool 
 		flags |= COMPARTMENT_FLAG_NS_USER;
 	if (ns_net)
 		flags |= COMPARTMENT_FLAG_NS_NET;
+
+	// set feature flags
 	if (allow_system_time)
 		flags |= COMPARTMENT_FLAG_SYSTEM_TIME;
 	if (allowed_module_list)
 		flags |= COMPARTMENT_FLAG_MODULE_LOAD;
+	if (xorg_compat)
+		flags |= COMPARTMENT_FLAG_XORG_COMPAT;
 
 	// create internal compartment object with container as extension data
 	compartment_extension_t *extension =

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -154,7 +154,7 @@ container_new(const uuid_t *uuid, const char *name, container_type_t type, bool 
 	      list_t *pnet_cfg_list, list_t *allowed_module_list, char **allowed_devices,
 	      char **assigned_devices, list_t *vnet_cfg_list, list_t *usbdev_list, const char *init,
 	      char **init_argv, char **init_env, size_t init_env_len, list_t *fifo_list,
-	      container_token_type_t ttype, bool usb_pin_entry);
+	      container_token_type_t ttype, bool usb_pin_entry, bool xorg_compat);
 
 /**
  * Free a container data structure.

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -133,6 +133,9 @@ message ContainerConfig {
 	required ContainerTokenType token_type = 30 [ default = SOFT ];
 
 	optional bool usb_pin_entry = 31 [ default = false ];
+
+	// enable module to support legacy xorg server
+	optional bool enable_xorg_compat = 32 [ default = false ];
 }
 
 /**

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -713,6 +713,15 @@ container_config_get_allow_system_time(const container_config_t *config)
 	return config->cfg->allow_system_time;
 }
 
+bool
+container_config_get_enable_xorg_compat(const container_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+
+	return config->cfg->enable_xorg_compat;
+}
+
 // hardcode some restricted config otpions in CC Mode
 #ifdef CC_MODE
 uint32_t

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -250,4 +250,7 @@ container_config_get_usbtoken_serial(const container_config_t *config);
 bool
 container_config_get_usb_pin_entry(const container_config_t *config);
 
+bool
+container_config_get_enable_xorg_compat(const container_config_t *config);
+
 #endif /* C_CONFIG_H */


### PR DESCRIPTION
Recent Linux kernel 6.9 changed device link of parent devices
in the sysfs. Newer xorg servers can handle this. However, to be
compatible with container payload which includes no recent xorg
server, we introduce this module. It will mount a tmpfs on the
/sys/class/graphics directory and links the included files, so
that it will compatible with old matching logic.

Especially, the link in /sys/class/graphics/fb0 may not include
a pci suffix to get recognized as platform device by legacy xorg
servers. Thus we link to bus/platform instead.