### PR TITLE
Seccomp mount

### DIFF
--- a/common/macro.h
+++ b/common/macro.h
@@ -771,7 +771,7 @@
 #define UNUSED __attribute__((unused))
 
 /**
- * Indicates that a funtion is executed in constructor context before main.
+ * Indicates that a function is executed in constructor context before main.
  * We use this to handle optional modules during build
  */
 #define INIT __attribute__((constructor))
@@ -786,6 +786,11 @@
 #define CAST(type) (type)
 #define CAST_FUNCPTR_VOIDPTR (void *)
 #endif
+
+/**
+ * Helper macro to cast an unsigned integer containing a pointer to a void pointer.
+ */
+#define CAST_UINT_VOIDPTR (void *)(uintptr_t)
 
 // math helpers
 #ifndef MIN

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -153,7 +153,8 @@ SRC_CSECCOMP = \
 	c_seccomp/init_module.c \
 	c_seccomp/adjtimex.c \
 	c_seccomp/ioctl.c \
-	c_seccomp/sysinfo.c
+	c_seccomp/sysinfo.c \
+	c_seccomp/mount.c
 
 SRC_CMODULES += \
 	c_net.c \

--- a/daemon/c_seccomp/adjtimex.c
+++ b/daemon/c_seccomp/adjtimex.c
@@ -62,7 +62,7 @@ c_seccomp_emulate_adjtime(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	}
 
 	DEBUG("Got clock_adjtime, clk_id: %lld, struct timex *: %p", req->data.args[0],
-	      (void *)req->data.args[1]);
+	      CAST_UINT_VOIDPTR req->data.args[1]);
 
 	// Check cap of target pid in its namespace
 	if (!c_seccomp_capable(req->pid, CAP_SYS_TIME)) {
@@ -76,8 +76,9 @@ c_seccomp_emulate_adjtime(c_seccomp_t *seccomp, struct seccomp_notif *req,
 		goto out;
 	}
 
-	if (!(timex = (struct timex *)c_seccomp_fetch_vm_new(
-		      seccomp, req->pid, (void *)req->data.args[1], sizeof(struct timex)))) {
+	if (!(timex = (struct timex *)c_seccomp_fetch_vm_new(seccomp, req->pid,
+							     CAST_UINT_VOIDPTR req->data.args[1],
+							     sizeof(struct timex)))) {
 		ERROR_ERRNO("Failed to fetch struct timex");
 		goto out;
 	}
@@ -114,7 +115,7 @@ c_seccomp_emulate_adjtimex(c_seccomp_t *seccomp, struct seccomp_notif *req,
 		goto out;
 	}
 
-	DEBUG("Got adjtimex, struct timex *: %p", (void *)req->data.args[0]);
+	DEBUG("Got adjtimex, struct timex *: %p", CAST_UINT_VOIDPTR req->data.args[0]);
 
 	// Check cap of target pid in its namespace
 	if (!c_seccomp_capable(req->pid, CAP_SYS_TIME)) {
@@ -122,8 +123,9 @@ c_seccomp_emulate_adjtimex(c_seccomp_t *seccomp, struct seccomp_notif *req,
 		goto out;
 	}
 
-	if (!(timex = (struct timex *)c_seccomp_fetch_vm_new(
-		      seccomp, req->pid, (void *)req->data.args[0], sizeof(struct timex)))) {
+	if (!(timex = (struct timex *)c_seccomp_fetch_vm_new(seccomp, req->pid,
+							     CAST_UINT_VOIDPTR req->data.args[0],
+							     sizeof(struct timex)))) {
 		ERROR_ERRNO("Failed to fetch struct timex");
 		goto out;
 	}
@@ -161,7 +163,7 @@ c_seccomp_emulate_settime(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	}
 
 	DEBUG("Got clock_settime, clockid: %lld, struct timespec *: %p", req->data.args[0],
-	      (void *)req->data.args[1]);
+	      CAST_UINT_VOIDPTR req->data.args[1]);
 
 	// Check cap of target pid in its namespace
 	if (!c_seccomp_capable(req->pid, CAP_SYS_TIME)) {
@@ -176,7 +178,8 @@ c_seccomp_emulate_settime(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	}
 
 	if (!(timespec = (struct timespec *)c_seccomp_fetch_vm_new(
-		      seccomp, req->pid, (void *)req->data.args[1], sizeof(struct timespec)))) {
+		      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[1],
+		      sizeof(struct timespec)))) {
 		ERROR_ERRNO("Failed to fetch struct timespec");
 		goto out;
 	}

--- a/daemon/c_seccomp/init_module.c
+++ b/daemon/c_seccomp/init_module.c
@@ -172,7 +172,7 @@ c_seccomp_emulate_finit_module(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	}
 
 	DEBUG("Got finit_module from pid %d, fd: %lld, const char params_values *: %p, flags: %lld",
-	      req->pid, req->data.args[0], (void *)req->data.args[1], req->data.args[2]);
+	      req->pid, req->data.args[0], CAST_UINT_VOIDPTR req->data.args[1], req->data.args[2]);
 
 	int fd_in_target = req->data.args[0];
 	int flags = req->data.args[2];
@@ -219,7 +219,7 @@ c_seccomp_emulate_finit_module(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	int param_max_len = 1024;
 	param_values = mem_alloc0(param_max_len);
 	if (!(param_values = (char *)c_seccomp_fetch_vm_new(
-		      seccomp, req->pid, (void *)req->data.args[1], param_max_len))) {
+		      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[1], param_max_len))) {
 		ERROR_ERRNO("Failed to fetch module parameters string");
 		goto out;
 	}

--- a/daemon/c_seccomp/ioctl.c
+++ b/daemon/c_seccomp/ioctl.c
@@ -177,25 +177,25 @@ c_seccomp_emulate_ioctl(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	switch (cmd) {
 	case RTC_EPOCH_SET:
 		TRACE("handling RTC_EPOCH_SET!");
-		if (!(param = (unsigned long)c_seccomp_fetch_vm_new(seccomp, req->pid,
-								    (void *)req->data.args[2],
-								    sizeof(unsigned long)))) {
+		if (!(param = (unsigned long)c_seccomp_fetch_vm_new(
+			      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[2],
+			      sizeof(unsigned long)))) {
 			ERROR_ERRNO("Failed to fetch struct rtc_time");
 		}
 		break;
 	case RTC_SET_TIME:
 		TRACE("handling RTC_SET_TIME!");
-		if (!(param = (unsigned long)c_seccomp_fetch_vm_new(seccomp, req->pid,
-								    (void *)req->data.args[2],
-								    sizeof(struct rtc_time)))) {
+		if (!(param = (unsigned long)c_seccomp_fetch_vm_new(
+			      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[2],
+			      sizeof(struct rtc_time)))) {
 			ERROR_ERRNO("Failed to fetch struct rtc_time");
 		}
 		break;
 	case RTC_PARAM_SET:
 		TRACE("handling RTC_PARAM_SET!");
-		if (!(param = (unsigned long)c_seccomp_fetch_vm_new(seccomp, req->pid,
-								    (void *)req->data.args[2],
-								    sizeof(struct rtc_param)))) {
+		if (!(param = (unsigned long)c_seccomp_fetch_vm_new(
+			      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[2],
+			      sizeof(struct rtc_param)))) {
 			ERROR_ERRNO("Failed to fetch struct rtc_time");
 		}
 		break;

--- a/daemon/c_seccomp/mknod.c
+++ b/daemon/c_seccomp/mknod.c
@@ -109,14 +109,14 @@ c_seccomp_emulate_mknodat(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	 */
 	if (req->data.nr == SYS_mknodat) {
 		DEBUG("Got %s() from pid %d, fd: %lld, const char *pathname: %p, mode: %lld, dev: %lld",
-		      syscall_name, req->pid, req->data.args[0], (void *)req->data.args[1],
-		      req->data.args[2], req->data.args[3]);
+		      syscall_name, req->pid, req->data.args[0],
+		      CAST_UINT_VOIDPTR req->data.args[1], req->data.args[2], req->data.args[3]);
 		dirfd = req->data.args[arg_offset];
 		arg_offset++;
 	} else { // SYS_mknod
 		DEBUG("Got %s() from pid %d, const char *pathname: %p, mode: %lld, dev: %lld",
-		      syscall_name, req->pid, (void *)req->data.args[0], req->data.args[1],
-		      req->data.args[2]);
+		      syscall_name, req->pid, CAST_UINT_VOIDPTR req->data.args[0],
+		      req->data.args[1], req->data.args[2]);
 		dirfd = AT_FDCWD;
 	}
 
@@ -141,9 +141,9 @@ c_seccomp_emulate_mknodat(c_seccomp_t *seccomp, struct seccomp_notif *req,
 
 	int pathname_max_len = PATH_MAX;
 	pathname = mem_alloc0(pathname_max_len);
-	if (!(pathname = (char *)c_seccomp_fetch_vm_new(seccomp, req->pid,
-							(void *)req->data.args[0 + arg_offset],
-							pathname_max_len))) {
+	if (!(pathname = (char *)c_seccomp_fetch_vm_new(
+		      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[0 + arg_offset],
+		      pathname_max_len))) {
 		ERROR_ERRNO("Failed to fetch pathname string");
 		goto out;
 	}

--- a/daemon/c_seccomp/mount.c
+++ b/daemon/c_seccomp/mount.c
@@ -1,0 +1,219 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2024 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file c_seccomp/mount.c
+ *
+ * This file is part of c_seccomp module. It contains the emulation code for the
+ * mount() system call.
+ */
+
+#define _GNU_SOURCE
+
+#include "../compartment.h"
+#include "../container.h"
+
+#include <common/file.h>
+#include <common/macro.h>
+#include <common/mem.h>
+#include <common/ns.h>
+
+#include "seccomp.h"
+
+#include <fcntl.h>
+#include <limits.h>
+#include <unistd.h>
+
+#include <sys/mount.h>
+
+#include <linux/capability.h>
+
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+struct mount_fork_data {
+	const char *source;
+	const char *target;
+	const char *filesystem;
+	unsigned long mountflags;
+	const void *data;
+};
+
+static int
+c_seccomp_do_mount_fork(const void *data)
+{
+	const struct mount_fork_data *params = data;
+	ASSERT(params);
+
+	DEBUG("Executing mount(source:%s, target:%s, fs:%s, flags:%lu, data:%s) in mountns of container",
+	      params->source, params->target, params->filesystem, params->mountflags,
+	      params->data ? (char *)params->data : "null");
+
+	if (-1 == mount(params->source, params->target, params->filesystem, params->mountflags,
+			params->data)) {
+		ERROR_ERRNO("Failed to execute mount");
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+c_seccomp_emulate_mount(c_seccomp_t *seccomp, struct seccomp_notif *req,
+			struct seccomp_notif_resp *resp)
+{
+	int ret_mount = 0;
+	char *source = NULL;
+	char *target = NULL;
+	char *filesystem = NULL;
+	unsigned long mountflags = 0;
+	void *data = NULL;
+
+	/*
+	 * in any case of error just continue the syscall in the kernel.
+	 * We just want to strip out SB_I_NODEV from file systems which may carry
+	 * device nodes, which are currently tmpfs, ramfs or overlayfs
+	 */
+	resp->error = 0;
+	resp->val = 0;
+	resp->flags = SECCOMP_USER_NOTIF_FLAG_CONTINUE;
+
+	/* We only handle mount if filesystem is set */
+	if (0 == req->data.args[2])
+		goto out;
+
+	TRACE("Got mount() from pid %d, const char *source: %p, const char *target: %p, "
+	      "const char * filesystem: %p, mountflags: %lld, const void *data: %p",
+	      req->pid, CAST_UINT_VOIDPTR req->data.args[0], CAST_UINT_VOIDPTR req->data.args[1],
+	      CAST_UINT_VOIDPTR req->data.args[2], req->data.args[3],
+	      CAST_UINT_VOIDPTR req->data.args[4]);
+
+	mountflags = req->data.args[3];
+
+	/* Check cap of target pid in its namespace */
+	if (!c_seccomp_capable(req->pid, CAP_SYS_ADMIN)) {
+		ERROR("Missing CAP_SYS_ADMIN for process %d!", req->pid);
+		goto out;
+	}
+
+	int max_len = PATH_MAX;
+	if (!(filesystem = (char *)c_seccomp_fetch_vm_new(
+		      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[2], max_len))) {
+		ERROR_ERRNO("Failed to fetch filesystem string");
+		goto out;
+	}
+
+	if (strcmp("tmpfs", filesystem) && strcmp("overlay", filesystem) &&
+	    strcmp("ramfs", filesystem)) {
+		TRACE("Unsuported filesystem, we only allow tmpfs | overlay | ramfs!");
+		goto out;
+	}
+
+	if (req->data.args[0]) {
+		if (!(source = (char *)c_seccomp_fetch_vm_new(
+			      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[0], max_len))) {
+			ERROR_ERRNO("Failed to fetch source string");
+			goto out;
+		}
+	}
+
+	if (req->data.args[1]) {
+		if (!(target = (char *)c_seccomp_fetch_vm_new(
+			      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[1], max_len))) {
+			ERROR_ERRNO("Failed to fetch target string");
+			goto out;
+		}
+	}
+
+	/*
+	 * some user space payload such as systemd privat devices, use proc related symlinks,
+	 * e.g. /proc/self/fd/4, as path. We have to read the link and put the real path as
+	 * target in those cases.
+	 */
+	if (strstr(target, "/proc")) {
+		char buf[PATH_MAX] = { 0 };
+
+		TRACE("Sanitize proc related path: %s", target);
+
+		if (1 == sscanf(target, "/proc/self/%s", buf)) {
+			mem_free0(target);
+			target = mem_printf("/proc/%d/%s", req->pid, buf);
+
+			TRACE("Sanitized new path: %s", target);
+
+			if (file_is_link(target)) {
+				if (readlink(target, buf, PATH_MAX) < 0)
+					TRACE_ERRNO("Readlink of %s failed.", target);
+				else {
+					mem_free0(target);
+					target = mem_strdup(buf);
+				}
+			}
+
+			TRACE("Sanitized new path real target: %s", target);
+		}
+	}
+
+	if (req->data.args[4]) {
+		if (!(data = c_seccomp_fetch_vm_new(
+			      seccomp, req->pid, CAST_UINT_VOIDPTR req->data.args[4], max_len))) {
+			ERROR_ERRNO("Failed to fetch data string");
+			goto out;
+		}
+	}
+
+	DEBUG("Executing mount on behalf of container %s", container_get_name(seccomp->container));
+
+	struct mount_fork_data mount_params = { .source = source,
+						.target = target,
+						.filesystem = filesystem,
+						.mountflags = mountflags,
+						.data = data };
+	if (-1 == (ret_mount = namespace_exec(req->pid, CLONE_NEWNS,
+					      container_get_uid(seccomp->container), CAP_SYS_ADMIN,
+					      c_seccomp_do_mount_fork, &mount_params))) {
+		ERROR_ERRNO("Failed to execute mount");
+		goto out;
+	}
+
+	DEBUG("mount returned %d", ret_mount);
+
+	// prepare answer
+	resp->id = req->id;
+	resp->error = 0;
+	resp->val = ret_mount;
+	/* mount emulated by us, so clear SECCOMP_USER_NOTIF_FLAG_CONTINUE flag */
+	resp->flags = 0;
+
+out:
+	if (source)
+		mem_free0(source);
+	if (target)
+		mem_free0(target);
+	if (filesystem)
+		mem_free0(filesystem);
+	if (data)
+		mem_free0(data);
+
+	return ret_mount;
+}

--- a/daemon/c_seccomp/seccomp.c
+++ b/daemon/c_seccomp/seccomp.c
@@ -227,8 +227,8 @@ c_seccomp_install_filter(c_seccomp_t *_seccomp)
 		 */
 		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_mknod, 0, 3),
 		BPF_STMT(BPF_LD | BPF_W | BPF_ABS, (offsetof(struct seccomp_data, args[1]))),
-		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFCHR, 11, 0),
-		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFBLK, 10, 0),
+		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFCHR, 12, 0),
+		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFBLK, 11, 0),
 #endif
 
 		/*
@@ -238,8 +238,10 @@ c_seccomp_install_filter(c_seccomp_t *_seccomp)
 		 */
 		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_mknodat, 0, 3),
 		BPF_STMT(BPF_LD | BPF_W | BPF_ABS, (offsetof(struct seccomp_data, args[2]))),
-		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFCHR, 7, 0),
-		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFBLK, 6, 0),
+		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFCHR, 8, 0),
+		BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, S_IFBLK, 7, 0),
+
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_mount, 6, 0),
 
 		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_sysinfo, 4, 0),
 
@@ -458,6 +460,10 @@ c_seccomp_handle_notify(int fd, unsigned events, UNUSED event_io_t *io, void *da
 	case SYS_sysinfo:
 		syscall_str = mem_strdup("SYS_sysinfo");
 		ret_syscall = c_seccomp_emulate_sysinfo(seccomp, req, resp);
+		break;
+	case SYS_mount:
+		syscall_str = mem_strdup("SYS_mount");
+		ret_syscall = c_seccomp_emulate_mount(seccomp, req, resp);
 		break;
 	default:
 		ret_syscall = 0;

--- a/daemon/c_seccomp/seccomp.h
+++ b/daemon/c_seccomp/seccomp.h
@@ -89,8 +89,13 @@ c_seccomp_ioctl_get_filter(c_seccomp_t *seccomp, int *size);
 int
 c_seccomp_emulate_ioctl(c_seccomp_t *seccomp, struct seccomp_notif *req,
 			struct seccomp_notif_resp *resp);
+
 int
 c_seccomp_emulate_sysinfo(c_seccomp_t *seccomp, struct seccomp_notif *req,
 			  struct seccomp_notif_resp *resp);
+
+int
+c_seccomp_emulate_mount(c_seccomp_t *seccomp, struct seccomp_notif *req,
+			struct seccomp_notif_resp *resp);
 
 #endif /* SECCOMP_H */

--- a/daemon/c_seccomp/sysinfo.c
+++ b/daemon/c_seccomp/sysinfo.c
@@ -378,7 +378,7 @@ c_seccomp_emulate_sysinfo(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	int ret_sysinfo = 0;
 	struct sysinfo *info;
 
-	TRACE("Got sysinfo, struct sysinfo *: %p", (void *)req->data.args[0]);
+	TRACE("Got sysinfo, struct sysinfo *: %p", CAST_UINT_VOIDPTR req->data.args[0]);
 	info = mem_new0(struct sysinfo, 1);
 
 	TRACE("Executing sysinfo on behalf of container");
@@ -387,7 +387,8 @@ c_seccomp_emulate_sysinfo(c_seccomp_t *seccomp, struct seccomp_notif *req,
 	struct sysinfo_fork_data sysinfo_params = { .seccomp = seccomp,
 						    .info = info,
 						    .target_pid = req->pid,
-						    .target_datap = (void *)req->data.args[0] };
+						    .target_datap =
+							    CAST_UINT_VOIDPTR req->data.args[0] };
 	if (-1 == (ret_sysinfo = namespace_exec(req->pid, CLONE_NEWALL & (~CLONE_NEWPID), 0, 0,
 						c_seccomp_do_sysinfo_fork, &sysinfo_params))) {
 		ERROR_ERRNO("Failed to execute sysinfo");


### PR DESCRIPTION
[daemon/c_seccomp: introduce mount() emulation](https://github.com/gyroidos/cml/commit/abdb2c24684d6ebe46e29d4e917a9998da39d31f)

Currently only handle tmpfs, ramfs and overlay mounts in cmld.
These mounts are allowed in unprivileged user namespace anyway.
However, since we also handle mknod() to allow to create device nodes
on such file systems. Without interception, the kernel implicitly
sets SB_I_NODEV to those mounts, leaving us with unusable device
nodes as open would fail with -EACCESS. Thus, handling this in the
cmld on behalf of the container, we get a mounted fileystem without
SB_I_NODEV. This will allow systemd's feature 'private devices' to
work in a cmld container.