### PR TITLE
common/network: more robust parsing in network_list_link_ns

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -852,7 +852,8 @@ cmld_audit_compartment_state_cb(container_t *container, container_callback_t *cb
 					uuid_string(container_get_uuid(container)), 0);
 		} else {
 			audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT,
-					"container-stop", uuid_string(container_get_uuid(container)), 0);
+					"container-stop",
+					uuid_string(container_get_uuid(container)), 0);
 		}
 		container_unregister_observer(container, cb);
 		break;


### PR DESCRIPTION
At first lines of network_list_link_ns does not match with lines returned in an element of the returned list list_line. Usually a line of list_line contained all line from one interface. However, sometimes this got garbled. We now read the output of the sub process with getline() and create a new list_line element each time we get an new line with ifindex at the beginning and if not we just append the string of the existing last element.