### PR TITLE
Token fixes: reattach token on container reload

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -620,6 +620,8 @@ cmld_reload_container(const uuid_t *uuid, const char *path)
 
 		cmld_containers_list = list_remove(cmld_containers_list, c_current);
 		container_free(c_current);
+		// container_free() releases the token in scd, thus reattach it
+		container_token_attach(c);
 	}
 
 	DEBUG("Loaded config for container %s", container_get_name(c));


### PR DESCRIPTION
[daemon/cmld: reattach token on container reload](https://github.com/gyroidos/cml/commit/46d0db234cad938c52b8bf12acda9c98a6f736d4)

On reload the new container object is created with container_new()
and afterwards the previous object is deleted by a call to
container_free(). Makes sens to first try to create the new updated
container object and only if this succeeds, the old object is
destroyed. However on container_new() the token is attached to the
scd and on container_free() it is removed:

Thus we now have the following behavior:

1) We have the token attached in the scd. The config updated kicks
   in and we get a new container object created by container_new().
   A second attach is made in the scd:
      <INFO>  control.c+221: Token already exists.

2) That is ok, we just ignore that in the scd and the new updated
   container object is created successfully.

3) However afterwards the container_free(<outdated container object>)
   is made and also the scd resources are released by an internal
   call to usbtoken_free() in scd:
      <DEBUG> usbtoken.c+603: Closing CT interface (ctn=0) done.

4) Since both container objects map to the same token in the scd, we
   now have no token attached in the scd anymore.

5) An attempt to do anything token related in the cmld now results
   in that the token is not available:
      <ERROR> control.c+254: No token loaded, unlock failed

Simply fix this by reattaching the token after the container_free()
of the outdated container.

Fixes: https://github.com/gyroidos/cml/commit/c13ef819d042e90e44c1677b0058d7f523e41a43 ("daemon/cmld: cleanup observer handling")
Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>