### PR TITLE
scd: refactoring sc-hsm-cardservice build

### DIFF
--- a/scd/Makefile
+++ b/scd/Makefile
@@ -27,6 +27,7 @@ AGGRESSIVE_WARNINGS ?= y
 SANITIZERS ?= n
 WCAST_ALIGN ?= y
 TRUSTME_SCHSM ?= n
+BNSE ?= n
 SYSTEMD ?= n
 
 LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -pedantic -O2
@@ -65,12 +66,24 @@ ifeq ($(SANITIZERS),y)
     LOCAL_CFLAGS += -lasan -fsanitize=address -fsanitize=undefined -fsanitize-recover=address
 endif
 ifeq ($(TRUSTME_SCHSM), y)
-    # If requested, we build sc-hsm support into trustme
-    LOCAL_CFLAGS += -DENABLESCHSM
+    # If requested, we build sc-cardservice with sc-hsm support into the scd
+    LOCAL_CFLAGS += -DCARDSERVICE_SCHSM
+    SC_CARDSERVICE = y
+    SRC_FILES += sc-hsm-lib/sc-hsm-cardservice.c
+endif
+ifeq ($(BNSE), y)
+    # If requested, we build sc-cardservice with bn-se support into the scd
+    SC_CARDSERVICE = y
+    LOCAL_CFLAGS += -DCARDSERVICE_BNSE
+    SRC_FILES += sc-hsm-lib/bn-se-cardservice.c
+endif
+ifeq ($(SC_CARDSERVICE), y)
+    # If requested, we build generic sc-cardservice support into the scd
+    # SC_CARDSERVICE is set internally by TRUSTE_SCHSM or BNSE.
+    # The direct use of SC_CARDSERVICE is not intended.
+    LOCAL_CFLAGS += -DSC_CARDSERVICE
 	LOCAL_LFLAGS += -lctccid
     SRC_FILES += \
-	sc-hsm-lib/sc-hsm-cardservice.c \
-	sc-hsm-lib/bn-se-cardservice.c \
 	sc-hsm-lib/cardservice.c \
 	usbtoken.c
 endif

--- a/scd/sc-hsm-lib/cardservice.c
+++ b/scd/sc-hsm-lib/cardservice.c
@@ -223,12 +223,12 @@ getCardService(int ctn)
 	struct cardService *cs;
 
 	cs = getBNSECardService();
-	if ((cs->selectSE)(ctn) == 0x9000) {
+	if (cs && (cs->selectSE)(ctn) == 0x9000) {
 		return cs;
 	}
 
 	cs = getSmartCardHSMCardService();
-	if ((cs->selectSE)(ctn) == 0x9000) {
+	if (cs && (cs->selectSE)(ctn) == 0x9000) {
 		return cs;
 	}
 

--- a/scd/sc-hsm-lib/cardservice.h
+++ b/scd/sc-hsm-lib/cardservice.h
@@ -70,7 +70,24 @@ processAPDU(int ctn, int todad, unsigned char CLA, unsigned char INS, unsigned c
 struct cardService *
 getCardService(int ctn);
 
+#ifdef CARDSERVICE_SCHSM
 struct cardService *
 getSmartCardHSMCardService();
+#else
+static inline struct cardService *
+getSmartCardHSMCardService();
+{
+	return NULL;
+}
+#endif
+
+#ifdef CARDSERVICE_BNSE
 struct cardService *
 getBNSECardService();
+#else
+static inline struct cardService *
+getBNSECardService()
+{
+	return NULL;
+}
+#endif

--- a/scd/token.c
+++ b/scd/token.c
@@ -34,7 +34,7 @@
 #include "common/list.h"
 #include "common/str.h"
 #include "common/fd.h"
-#include "file.h"
+#include "common/file.h"
 #include "unistd.h"
 
 #define SCD_TOKENCONTROL_SOCK_LISTEN_BACKLOG 1
@@ -60,7 +60,7 @@ struct scd_token_data {
 	tctrl_t *tctrl;
 };
 
-#ifdef ENABLESCHSM // tokencontrol socket only relevant for usbtoken
+#ifdef SC_CARDSERVICE // tokencontrol socket only relevant for usbtoken
 static void
 wrapped_remove_event_io(void *elem)
 {
@@ -332,7 +332,7 @@ scd_tokencontrol_free(scd_token_t *token)
 
 	mem_free0(token->token_data->tctrl);
 }
-#endif // ENABLESCHSM
+#endif // SC_CARDSERVICE
 
 /*** internal helper functions ***/
 
@@ -408,7 +408,7 @@ int_get_atr_st(UNUSED scd_token_t *token, UNUSED unsigned char *brsp, UNUSED siz
 	return -1;
 }
 
-#ifdef ENABLESCHSM
+#ifdef SC_CARDSERVICE
 
 int
 int_lock_usb(scd_token_t *token)
@@ -482,7 +482,7 @@ int_get_atr_usb(scd_token_t *token, unsigned char *brsp, size_t brsp_len)
 {
 	return usbtoken_get_atr(token->token_data->int_token.usbtoken, brsp, brsp_len);
 }
-#endif // ENABLESCHSM
+#endif // SC_CARDSERVICE
 
 scd_token_t *
 token_new(const token_constr_data_t *constr_data)
@@ -552,7 +552,7 @@ token_new(const token_constr_data_t *constr_data)
 		new_token->send_apdu = int_send_apdu_st;
 		break;
 	}
-#ifdef ENABLESCHSM
+#ifdef SC_CARDSERVICE
 	case (USB): {
 		DEBUG("Create scd_token with internal type 'USB'");
 
@@ -584,7 +584,7 @@ token_new(const token_constr_data_t *constr_data)
 		new_token->send_apdu = int_send_apdu_usb;
 		break;
 	}
-#endif // ENABLESCHSM
+#endif // SC_CARDSERVICE
 	default:
 		ERROR("Unrecognized token type");
 		goto err;
@@ -648,12 +648,12 @@ token_free(scd_token_t *token)
 			softtoken_remove_p12(token->token_data->int_token.softtoken);
 			softtoken_free(token->token_data->int_token.softtoken);
 			break;
-#ifdef ENABLESCHSM
+#ifdef SC_CARDSERVICE
 		case (USB):
 			scd_tokencontrol_free(token);
 			usbtoken_free(token->token_data->int_token.usbtoken);
 			break;
-#endif // ENABLESCHSM
+#endif // SC_CARDSERVICE
 		default:
 			ERROR("Failed to determine token type. Cannot clean up");
 			return;

--- a/scd/usbtoken.c
+++ b/scd/usbtoken.c
@@ -30,6 +30,7 @@
 
 #include "common/macro.h"
 #include "common/mem.h"
+#include "common/dir.h"
 #include "common/file.h"
 #include "common/list.h"
 #include "common/str.h"
@@ -1032,3 +1033,12 @@ usbtoken_get_atr(usbtoken_t *token, unsigned char *buf, size_t buflen)
 
 	return token->latr_len;
 }
+
+#ifdef DEBUG_BUILD
+static void INIT
+usbtoken_init(void)
+{
+	DEBUG("Creating libctccid log directory at /var/tmp/sc-hsm-embedded");
+	dir_mkdir_p("/var/tmp/sc-hsm-embedded", 0755);
+}
+#endif

--- a/scd/usbtoken.h
+++ b/scd/usbtoken.h
@@ -31,7 +31,7 @@
 
 typedef struct usbtoken usbtoken_t;
 
-#ifdef ENABLESCHSM
+#ifdef SC_CARDSERVICE
 
 /**
  * Initializes a usb token, iff the serial number of the usb token reader matches
@@ -173,6 +173,6 @@ usbtoken_reset_auth(usbtoken_t *token, unsigned char *brsp, size_t brsp_len);
 int
 usbtoken_get_atr(usbtoken_t *token, unsigned char *brsp, size_t brsp_len);
 
-#endif
+#endif // SC_CARDSERVICE
 
-#endif // ENABLESCHSM
+#endif // USBTOKEN_H


### PR DESCRIPTION
Allow more fine grained control about what is going to be built into the scd binary according to sc-hsm-lib cardservice.