### PR TITLE
daemon/compartment: append instead of prepend observers

### DIFF
--- a/daemon/compartment.c
+++ b/daemon/compartment.c
@@ -1744,7 +1744,7 @@ compartment_register_observer(compartment_t *compartment,
 	compartment_callback_t *ccb = mem_new0(compartment_callback_t, 1);
 	ccb->cb = cb;
 	ccb->data = data;
-	compartment->observer_list = list_prepend(compartment->observer_list, ccb);
+	compartment->observer_list = list_append(compartment->observer_list, ccb);
 	return ccb;
 }
 


### PR DESCRIPTION
In compartment_register_observers, callbacks are prepended to the list of callbacks. However, in 'cmld.c' the sync as well as the destroy callback are considered to at the end of the list, and thus it should be safe to destroy the container and thus also the inner compartment object. In the notify_observers on the other hand the list of observers is called from the head to the tail of the list. Due to the registration order the sync callback is called first and with that the container and compartment objects are freed, while the rest of the observers are called on the already freed compartment object.

We now just switch back to append the observers instead of prepending them in compartment_register_observers().

This fixes following ASAN error:
================================================================= ==174==ERROR: AddressSanitizer: heap-use-after-free on address 0x5100000009b8 \
 at pc 0x55bd534973a5 bp 0x7fff58c59c90 sp 0x7fff58c59c80
READ of size 8 at 0x5100000009b8 thread T0
    #0 0x55bd534973a4 in compartment_notify_observers daemon/compartment.c:1677
    #1 0x55bd5349cd49 in compartment_sigchld_handle_helpers daemon/compartment.c:700
    #2 0x55bd5349d319 in compartment_sigchld_cb daemon/compartment.c:783
    #3 0x55bd53543329 in event_signal_handler common/event.c:780
    #4 0x55bd53543329 in event_loop common/event.c:851
    #5 0x55bd5347b6ac in main daemon/main.c:146
    #6 0x7f4ac17fb863 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x7f4ac17fb90a in __libc_start_main_impl ../csu/libc-start.c:389
    #8 0x55bd5347d9d4 in _start (/usr/sbin/cmld+0x13e9d4)

Fixes: e816bafc026a ("daemon/cmld: Properly register config_sync_cb")