### PR TITLE
scd/scd: fix unused parameters in main

### DIFF
--- a/scd/scd.c
+++ b/scd/scd.c
@@ -315,10 +315,8 @@ main_init(void)
 }
 
 int
-main(int argc, char **argv)
+main(UNUSED int argc, UNUSED char **argv)
 {
-	ASSERT(argc >= 1);
-
 	event_timer_t *logfile_timer = event_timer_new(
 		HOURS_TO_MILLISECONDS(24), EVENT_TIMER_REPEAT_FOREVER, scd_logfile_rename_cb, NULL);
 	event_add_timer(logfile_timer);


### PR DESCRIPTION
Removing the deprectated Android code in commit f75193ffc0b56 ("scd: refactoring sc-hsm-cardservice build") left over unused argc and argv parameters. Just declare those as UNUSED.

Fixes: f75193ffc0b5 ("scd: refactoring sc-hsm-cardservice build")