### PR TITLE
daemon/cmld: fix use-after-free during compartment destroy

### DIFF
--- a/daemon/c_automount.c
+++ b/daemon/c_automount.c
@@ -242,22 +242,13 @@ c_automount_start_post_exec(void *automountp)
 	return 0;
 }
 
-static int
-c_automount_stop(void *automountp)
-{
-	c_automount_t *automount = automountp;
-	ASSERT(automount);
-
-	event_remove_inotify(automount->inotify_dev);
-
-	return 0;
-}
-
 static void
 c_automount_cleanup(void *automountp, UNUSED bool rebooting)
 {
 	c_automount_t *automount = automountp;
 	ASSERT(automount);
+
+	event_remove_inotify(automount->inotify_dev);
 
 	char *mnt_media = mem_printf("%s/media", container_get_rootdir(automount->container));
 	if (umount(mnt_media) < 0)
@@ -279,7 +270,7 @@ static compartment_module_t c_automount_module = {
 	.start_post_exec = c_automount_start_post_exec,
 	.start_child = c_automount_start_child,
 	.start_pre_exec_child = NULL,
-	.stop = c_automount_stop,
+	.stop = NULL,
 	.cleanup = c_automount_cleanup,
 	.join_ns = NULL,
 };


### PR DESCRIPTION
While destroying a container, a use-after-free occurred, since the used observer callback in cmld.c frees the container and therefore also the compartment before all other registered observers where called.

Similarly to the container reload, we now use the observer finish callback to do a delayed free after all compartments observer callbacks have been run.

This fixes asan error:

================================================================= ==203==ERROR: AddressSanitizer: heap-use-after-free on address \
 0x511000000838 at pc 0x557253082656 bp 0x7ffe4cfee190 sp 0x7ffe4cfee180
READ of size 8 at 0x511000000838 thread T0
    #0 0x557253082655 in compartment_notify_observers daemon/compartment.c:1681
    #1 0x557253088149 in compartment_sigchld_handle_helpers daemon/compartment.c:705
    #2 0x5572530886c9 in compartment_sigchld_cb daemon/compartment.c:787
    #3 0x55725312e759 in event_signal_handler common/event.c:780
    #4 0x55725312e759 in event_loop common/event.c:851
    #5 0x5572530666ac in main daemon/main.c:146
    #6 0x7ff708bd5863 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x7ff708bd590a in __libc_start_main_impl ../csu/libc-start.c:389
    #8 0x5572530689d4 in _start (/usr/sbin/cmld+0x13e9d4)