### PR TITLE
cleanup rework of trustme leftovers

### DIFF
--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -53,7 +53,7 @@
 //#define CITY_L_CSR "Muenchen"
 #define ORGANIZATION_O_CSR "Fraunhofer"
 #define ORG_UNIT_OU1_CSR "AISEC"
-//#define ORG_UNIT_OU2_CSR "trustme"
+//#define ORG_UNIT_OU2_CSR "gyroidos"
 #define KEY_USAGE_CSR "critical, digitalSignature,keyEncipherment,nonRepudiation"
 #define EXT_KEY_USAGE_CSR "clientAuth"
 #define REQ_VERSION_CSR 0L
@@ -80,7 +80,7 @@
 #define TEST_L "Muenchen"
 #define TEST_O "Fraunhofer"
 #define TEST_OU1 "AISEC"
-#define TEST_OU2 "trustme"
+#define TEST_OU2 "gyroidos"
 #define TEST_BASIC_CONSTRAINTS "critical,CA:FALSE"
 #define TEST_KEY_USAGE_CERT "critical,keyCertSign,cRLSign"
 #define TEST_KEY_IDENTIFIER "hash"
@@ -88,7 +88,7 @@
 #define TEST_NOT_BEFORE 0
 #define TEST_NOT_AFTER (60 * 60 * 24 * 365)
 #define TEST_CERT_VERSION 2
-#define TEST_FRIENDLY_NAME "trust-me test user"
+#define TEST_FRIENDLY_NAME "gyroidos test user"
 
 /* creates a certificate containing the public key pkeyp with
  * serial number and validity in days (for user.p12) */

--- a/common/testdata/cert_confs/openssl-ssig-cml.cnf
+++ b/common/testdata/cert_confs/openssl-ssig-cml.cnf
@@ -21,7 +21,7 @@ organizationalUnitName	= Organizational Unit Name (department, division)
 organizationalUnitName_default 	= Development
 
 commonName          = Common Name (e.g. server FQDN or YOUR name)
-commonName_default      = trustme CML Signing Certificate
+commonName_default      = unittest CML Signing Certificate
 
 ####################################################################
 [ user_req_extensions ]

--- a/common/testdata/cert_confs/openssl-ssig-rootca.cnf
+++ b/common/testdata/cert_confs/openssl-ssig-rootca.cnf
@@ -46,7 +46,7 @@ organizationalUnitName		= Organizational Unit Name (eg, section)
 organizationalUnitName_default	= Development
 
 commonName          = Common Name (e.g. server FQDN or YOUR name)
-commonName_default      = trustme Software Signing Root CA
+commonName_default      = unittest Software Signing Root CA
 
 ####################################################################
 [ ca_extensions ]

--- a/common/testdata/cert_confs/openssl-ssig-subca-cml.cnf
+++ b/common/testdata/cert_confs/openssl-ssig-subca-cml.cnf
@@ -46,7 +46,7 @@ organizationalUnitName		= Organizational Unit Name (eg, section)
 organizationalUnitName_default	= Development
 
 commonName          = Common Name (e.g. server FQDN or YOUR name)
-commonName_default      = trustme CML Signing Sub CA
+commonName_default      = unittest CML Signing Sub CA
 
 ####################################################################
 [ ca_extensions ]

--- a/common/testdata/cert_confs/openssl-ssig-subca.cnf
+++ b/common/testdata/cert_confs/openssl-ssig-subca.cnf
@@ -46,7 +46,7 @@ organizationalUnitName		= Organizational Unit Name (eg, section)
 organizationalUnitName_default	= Development
 
 commonName          = Common Name (e.g. server FQDN or YOUR name)
-commonName_default      = trustme Software Signing Sub CA
+commonName_default      = unittest Software Signing Sub CA
 
 ####################################################################
 [ ca_extensions ]

--- a/common/testdata/cert_confs/openssl-ssig.cnf
+++ b/common/testdata/cert_confs/openssl-ssig.cnf
@@ -21,7 +21,7 @@ organizationalUnitName	= Organizational Unit Name (department, division)
 organizationalUnitName_default 	= Development
 
 commonName          = Common Name (e.g. server FQDN or YOUR name)
-commonName_default      = trustme Software Signing Certificate
+commonName_default      = unittest Software Signing Certificate
 
 ####################################################################
 [ user_req_extensions ]

--- a/common/testdata/create_certs.sh
+++ b/common/testdata/create_certs.sh
@@ -52,8 +52,8 @@ DAYS_VALID="365"
 KEY_SIZE="4096"
 
 
-PASS_IN="-passin env:TRUSTME_TEST_PASSWD_PKI"
-PASS_OUT="-passout env:TRUSTME_TEST_PASSWD_PKI"
+PASS_IN="-passin env:GYROIDOS_TEST_PASSWD_PKI"
+PASS_OUT="-passout env:GYROIDOS_TEST_PASSWD_PKI"
 
 
 
@@ -62,7 +62,7 @@ SSIG_ROOTCA_INDEX_FILE="ssig_rootca_index.txt"
 SSIG_SUBCA_CML_INDEX_FILE="ssig_subca_cml_index.txt"
 SSIG_SUBCA_INDEX_FILE="ssig_subca_index.txt"
 
-export TRUSTME_TEST_PASSWD_PKI
+export GYROIDOS_TEST_PASSWD_PKI
 
 error_check(){
 if [ "$1" != "0" ]; then

--- a/common/testdata/gen_testvectors.sh
+++ b/common/testdata/gen_testvectors.sh
@@ -5,7 +5,7 @@
 PKI_DIR_TRUSTED="testpki"
 PKI_DIR_UNTRUSTED="testpki_untrusted"
 
-export TRUSTME_TEST_PASSWD_PKI="test1234"
+export GYROIDOS_TEST_PASSWD_PKI="test1234"
 
 ########## Tokens and Certificates ##########
 # Create PKCS12 tokens
@@ -18,10 +18,10 @@ bash create_certs.sh "${PKI_DIR_TRUSTED}"
 bash create_certs.sh "${PKI_DIR_UNTRUSTED}"
 
 echo "Creating PKCS#11 token using ${PKI_DIR_TRUSTED}/ssig_cml.key and ${PKI_DIR_TRUSTED}/ssig_cml.cert"
-TRUSTME_TEST_PASSWD_PKI="test1234" openssl pkcs12 -export -out token_pss.p12 -inkey ${PKI_DIR_TRUSTED}/ssig_cml.key -in ${PKI_DIR_TRUSTED}/ssig_cml.cert -passin env:TRUSTME_TEST_PASSWD_PKI -password pass:trustme
+GYROIDOS_TEST_PASSWD_PKI="test1234" openssl pkcs12 -export -out token_pss.p12 -inkey ${PKI_DIR_TRUSTED}/ssig_cml.key -in ${PKI_DIR_TRUSTED}/ssig_cml.cert -passin env:GYROIDOS_TEST_PASSWD_PKI -password pass:trustme
 
 echo "Creating PKCS#11 token using ${PKI_DIR_TRUSTED}/ssig.key and ${PKI_DIR_TRUSTED}/ssig.cert"
-TRUSTME_TEST_PASSWD_PKI="test1234" openssl pkcs12 -export -out token.p12 -inkey ${PKI_DIR_TRUSTED}/ssig.key -in ${PKI_DIR_TRUSTED}/ssig.cert -passin env:TRUSTME_TEST_PASSWD_PKI -password pass:trustme
+GYROIDOS_TEST_PASSWD_PKI="test1234" openssl pkcs12 -export -out token.p12 -inkey ${PKI_DIR_TRUSTED}/ssig.key -in ${PKI_DIR_TRUSTED}/ssig.cert -passin env:GYROIDOS_TEST_PASSWD_PKI -password pass:trustme
 
 ########## Combined cert file ##########
 cp testpki_untrusted/ssig_rootca.cert untrusted_chain_including_rootca.cert
@@ -45,15 +45,15 @@ openssl dgst -sha512 -binary test-quote > test-quote-hash_sha512
 COMMON_PKEYOPTS_PSS="-pkeyopt rsa_padding_mode:pss -pkeyopt rsa_pss_saltlen:digest"
 
 echo "Creating sigpss_psscert_sha256"
-openssl pkeyutl -sign -digest SHA256 -pkeyopt rsa_mgf1_md:SHA256 $COMMON_PKEYOPTS_PSS -inkey testpki/ssig_cml.key -passin env:TRUSTME_TEST_PASSWD_PKI -rawin -in test-quote -out sigpss_psscert_sha256
+openssl pkeyutl -sign -digest SHA256 -pkeyopt rsa_mgf1_md:SHA256 $COMMON_PKEYOPTS_PSS -inkey testpki/ssig_cml.key -passin env:GYROIDOS_TEST_PASSWD_PKI -rawin -in test-quote -out sigpss_psscert_sha256
 echo "Creating sigpss_psscert_sha512"
-openssl pkeyutl -sign -digest SHA512 -pkeyopt rsa_mgf1_md:SHA512 $COMMON_PKEYOPTS_PSS -inkey testpki/ssig_cml.key -passin env:TRUSTME_TEST_PASSWD_PKI -rawin -in test-quote -out sigpss_psscert_sha512
+openssl pkeyutl -sign -digest SHA512 -pkeyopt rsa_mgf1_md:SHA512 $COMMON_PKEYOPTS_PSS -inkey testpki/ssig_cml.key -passin env:GYROIDOS_TEST_PASSWD_PKI -rawin -in test-quote -out sigpss_psscert_sha512
 
 echo "Creating sigssa_ssacert_sha256"
-openssl pkeyutl -sign -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-256 -inkey testpki/ssig.key -passin env:TRUSTME_TEST_PASSWD_PKI -rawin -in test-quote -out sigssa_ssacert_sha256
+openssl pkeyutl -sign -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-256 -inkey testpki/ssig.key -passin env:GYROIDOS_TEST_PASSWD_PKI -rawin -in test-quote -out sigssa_ssacert_sha256
 
 echo "Creating sigssa_ssacert_sha512"
-openssl pkeyutl -sign -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-512 -inkey testpki/ssig.key -passin env:TRUSTME_TEST_PASSWD_PKI -rawin -in test-quote -out sigssa_ssacert_sha512
+openssl pkeyutl -sign -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-512 -inkey testpki/ssig.key -passin env:GYROIDOS_TEST_PASSWD_PKI -rawin -in test-quote -out sigssa_ssacert_sha512
 
 
 # Verify Signatures
@@ -63,7 +63,7 @@ echo "Verifying sigpss_psscert_sha512"
 openssl pkeyutl -verify -digest SHA512 $COMMON_PKEYOPTS_PSS -pkeyopt rsa_mgf1_md:SHA512 -sigfile sigpss_psscert_sha512 -certin -inkey testpki/ssig_cml_single.cert -rawin -in test-quote
 
 echo "Verifying sigssa_ssacert_sha256"
-openssl pkeyutl -verify -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-256 -sigfile  sigssa_ssacert_sha256 -inkey testpki/ssig.key -passin env:TRUSTME_TEST_PASSWD_PKI -rawin -in test-quote
+openssl pkeyutl -verify -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-256 -sigfile  sigssa_ssacert_sha256 -inkey testpki/ssig.key -passin env:GYROIDOS_TEST_PASSWD_PKI -rawin -in test-quote
 
 echo "Verifying sigssa_ssacert_sha512"
-openssl pkeyutl -verify -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-512 -sigfile  sigssa_ssacert_sha512 -inkey testpki/ssig.key -passin env:TRUSTME_TEST_PASSWD_PKI -rawin -in test-quote
+openssl pkeyutl -verify -pkeyopt rsa_padding_mode:pkcs1 -digest SHA-512 -sigfile  sigssa_ssacert_sha512 -inkey testpki/ssig.key -passin env:GYROIDOS_TEST_PASSWD_PKI -rawin -in test-quote

--- a/daemon/c_automount.c
+++ b/daemon/c_automount.c
@@ -242,22 +242,13 @@ c_automount_start_post_exec(void *automountp)
 	return 0;
 }
 
-static int
-c_automount_stop(void *automountp)
-{
-	c_automount_t *automount = automountp;
-	ASSERT(automount);
-
-	event_remove_inotify(automount->inotify_dev);
-
-	return 0;
-}
-
 static void
 c_automount_cleanup(void *automountp, UNUSED bool rebooting)
 {
 	c_automount_t *automount = automountp;
 	ASSERT(automount);
+
+	event_remove_inotify(automount->inotify_dev);
 
 	char *mnt_media = mem_printf("%s/media", container_get_rootdir(automount->container));
 	if (umount(mnt_media) < 0)
@@ -279,7 +270,7 @@ static compartment_module_t c_automount_module = {
 	.start_post_exec = c_automount_start_post_exec,
 	.start_child = c_automount_start_child,
 	.start_pre_exec_child = NULL,
-	.stop = c_automount_stop,
+	.stop = NULL,
 	.cleanup = c_automount_cleanup,
 	.join_ns = NULL,
 };

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -23,7 +23,7 @@
 
 #ifdef DEBUG_BUILD
 // prevent reboot in debug build
-#define TRUSTME_DEBUG
+#define NO_REBOOT_ON_EXIT
 #endif
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
@@ -1119,12 +1119,12 @@ cmld_c0_boot_complete_cb(container_t *container, container_callback_t *cb, UNUSE
 static void
 cmld_handle_device_shutdown(void)
 {
-#ifdef TRUSTME_DEBUG
+#ifdef NO_REBOOT_ON_EXIT
 	if (cmld_device_reboot == POWER_OFF) {
 		DEBUG("Device shutdown: keep CML running, just exit cmld for debugging.");
 		exit(0);
 	}
-#endif /* TRUSTME_DEBUG */
+#endif /* NO_REBOOT_ON_EXIT */
 
 	reboot_reboot(cmld_device_reboot);
 	// should never arrive here, but in case the shutdown fails somehow, we exit

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -47,8 +47,8 @@
 #define GUESTOS_MGR_VERIFY_HASH_ALGO SHA512
 #define GUESTOS_MGR_FILE_MOVE_BLOCKSIZE 4096
 
-// Log title and messages regarding trustme system updates.
-#define GUESTOS_MGR_UPDATE_TITLE "Trustme Update"
+// Log title and messages regarding gyroidos system updates.
+#define GUESTOS_MGR_UPDATE_TITLE "GyroidOS Update"
 #define GUESTOS_MGR_UPDATE_DOWNLOAD "Downloading..."
 #define GUESTOS_MGR_UPDATE_SUCCESS "Reboot to install/activate"
 #define GUESTOS_MGR_UPDATE_FLASH_FAILED "Flashing to device partitions failed"

--- a/scd/Makefile
+++ b/scd/Makefile
@@ -26,7 +26,7 @@ DEVELOPMENT_BUILD ?= y
 AGGRESSIVE_WARNINGS ?= y
 SANITIZERS ?= n
 WCAST_ALIGN ?= y
-TRUSTME_SCHSM ?= n
+SCHSM ?= n
 BNSE ?= n
 SYSTEMD ?= n
 
@@ -65,7 +65,7 @@ ifeq ($(SANITIZERS),y)
     # to be installed on the build host
     LOCAL_CFLAGS += -lasan -fsanitize=address -fsanitize=undefined -fsanitize-recover=address
 endif
-ifeq ($(TRUSTME_SCHSM), y)
+ifeq ($(SCHSM), y)
     # If requested, we build sc-cardservice with sc-hsm support into the scd
     LOCAL_CFLAGS += -DCARDSERVICE_SCHSM
     SC_CARDSERVICE = y
@@ -79,7 +79,7 @@ ifeq ($(BNSE), y)
 endif
 ifeq ($(SC_CARDSERVICE), y)
     # If requested, we build generic sc-cardservice support into the scd
-    # SC_CARDSERVICE is set internally by TRUSTE_SCHSM or BNSE.
+    # SC_CARDSERVICE is set internally by SCHSM or BNSE.
     # The direct use of SC_CARDSERVICE is not intended.
     LOCAL_CFLAGS += -DSC_CARDSERVICE
 	LOCAL_LFLAGS += -lctccid


### PR DESCRIPTION
Current rework of gyroidos reositries replaced all legacy variable nameing thus we have to take this into account here, too. We replace the build variable TRUSTME_SCHSM by SCHSM.