### PR TITLE
common/cryptfs: Adapt integrity dev formatting

### DIFF
--- a/common/fd.c
+++ b/common/fd.c
@@ -34,7 +34,7 @@
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
 ssize_t
-fd_write(int fd, const char *buf, size_t len)
+fd_write(int fd, const char *buf, ssize_t len)
 {
 	size_t remain = len;
 

--- a/common/fd.c
+++ b/common/fd.c
@@ -30,6 +30,9 @@
 #include "macro.h"
 #include "fd.h"
 
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
 ssize_t
 fd_write(int fd, const char *buf, size_t len)
 {
@@ -59,6 +62,10 @@ fd_write(int fd, const char *buf, size_t len)
 
 		if (ret == 0)
 			break;
+	}
+
+	if (0 != fsync(fd)) {
+		TRACE("Could not sync fd %d", fd);
 	}
 
 	return len - remain;

--- a/common/fd.c
+++ b/common/fd.c
@@ -30,7 +30,7 @@
 #include "macro.h"
 #include "fd.h"
 
-int
+ssize_t
 fd_write(int fd, const char *buf, size_t len)
 {
 	size_t remain = len;

--- a/common/fd.h
+++ b/common/fd.h
@@ -42,7 +42,7 @@
  * @param len length of the buffer
  */
 ssize_t
-fd_write(const int fd, const char *buf, size_t len);
+fd_write(const int fd, const char *buf, ssize_t len);
 
 /*
  * Reads the specified amount of bytes from the given file descriptor to the given buffer,

--- a/common/fd.h
+++ b/common/fd.h
@@ -41,7 +41,7 @@
  * @param buf pointer to the buffer
  * @param len length of the buffer
  */
-int
+ssize_t
 fd_write(const int fd, const char *buf, size_t len);
 
 /*

--- a/common/file.c
+++ b/common/file.c
@@ -192,6 +192,11 @@ file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, o
 		}
 	}
 
+	if (0 != fsync(out_fd)) {
+		TRACE_ERRNO("Could not sync fd %d", out_fd);
+	}
+
+	ret = 0;
 	goto out;
 
 	// slow copy as fallback
@@ -220,6 +225,10 @@ fallback:
 				goto out_fallback;
 			}
 		}
+	}
+
+	if (0 != fsync(out_fd)) {
+		TRACE_ERRNO("Could not sync fd %d", out_fd);
 	}
 
 out_fallback:
@@ -269,6 +278,10 @@ file_write_internal(const char *file, const char *buf, ssize_t len, int oflags)
 		DEBUG("Could not write to output file %s", file);
 		close(fd);
 		return -1;
+	}
+
+	if (0 != fsync(fd)) {
+		TRACE_ERRNO("Could not sync fd %d", fd);
 	}
 
 	close(fd);

--- a/common/logf.c
+++ b/common/logf.c
@@ -378,7 +378,12 @@ logf_file_write(logf_prio_t prio, const char *msg, void *data)
 
 	logf_file_write_timestamp(data);
 	fprintf(data, "[%u] %s %s\n", getpid(), prio_str(prio), msg);
-	fflush(data);
+
+	int res = -1;
+	if (0 != (res = fflush(data))) {
+		ERROR_ERRNO("Failed to flush log file for PID %d after message %s: %d", getpid(),
+			    msg, res);
+	}
 }
 
 void
@@ -388,7 +393,12 @@ logf_test_write(logf_prio_t prio, const char *msg, void *data)
 		return;
 
 	fprintf(data, "[%u] %s %s\n", getpid(), prio_str(prio), msg);
-	fflush(data);
+
+	int res = -1;
+	if (0 != (res = fflush(data))) {
+		ERROR_ERRNO("Failed to flush log file for PID %d after message %s: %d", getpid(),
+			    msg, res);
+	}
 }
 
 void *

--- a/common/macro.h
+++ b/common/macro.h
@@ -41,9 +41,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <unistd.h>
 #include <time.h>
 
 #include "logf.h"
+
+// sync fs
+#define SYNC_INFO()                                                                                \
+	{                                                                                          \
+		sync();                                                                            \
+		INFO("Synced file systems");                                                       \
+		sync();                                                                            \
+	}
 
 //sleep
 #define NANOSLEEP(sec, nsec)                                                                       \

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -109,6 +109,14 @@ main_init(void)
 	main_core_dump_enable();
 }
 
+static void
+main_sync_fs()
+{
+	if (!cmld_is_hostedmode_active()) {
+		SYNC_INFO()
+	}
+}
+
 /******************************************************************************/
 
 int
@@ -141,6 +149,9 @@ main(int argc, char **argv)
 		FATAL("Could not init cmld");
 
 	if (atexit(&cmld_cleanup))
+		WARN("could not register on exit cleanup method 'cmld_cleanup()'");
+
+	if (atexit(&main_sync_fs))
 		WARN("could not register on exit cleanup method 'cmld_cleanup()'");
 
 	event_loop();

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -80,8 +80,6 @@ scd_sigterm_cb(UNUSED int signum, UNUSED event_signal_t *sig, UNUSED void *data)
 		logf_unregister(scd_logfile_handler);
 		logf_file_close(scd_logfile_p);
 	}
-
-	SYNC_INFO()
 	exit(0);
 }
 
@@ -287,6 +285,12 @@ main_init(void)
 	logf_handler_set_prio(scd_logfile_handler, LOGF_PRIO_TRACE);
 }
 
+static void
+main_sync_fs()
+{
+	SYNC_INFO();
+}
+
 int
 main(UNUSED int argc, UNUSED char **argv)
 {
@@ -296,6 +300,9 @@ main(UNUSED int argc, UNUSED char **argv)
 
 	event_signal_t *sig_term = event_signal_new(SIGTERM, &scd_sigterm_cb, NULL);
 	event_add_signal(sig_term);
+
+	if (atexit(&main_sync_fs))
+		WARN("could not register on exit cleanup method 'cmld_cleanup()'");
 
 	provisioning_mode();
 

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -80,6 +80,8 @@ scd_sigterm_cb(UNUSED int signum, UNUSED event_signal_t *sig, UNUSED void *data)
 		logf_unregister(scd_logfile_handler);
 		logf_file_close(scd_logfile_p);
 	}
+
+	SYNC_INFO()
 	exit(0);
 }
 


### PR DESCRIPTION
This PR leverages a buffer allocated via calloc's copy-on-write-based approach together with the fd_write implementation in common/fd.c implementation to increase the speed of initial formatting while not requiring a large amount of physical memory.