### PR TITLE
common/Makefile: Fix dependencies for audit.proto

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -61,7 +61,10 @@ endif
 all: libcommon
 
 .PHONY: protobuf
-protobuf: audit.pb-c.c
+protobuf audit.pb-c.h audit.pb-c.c: audit.proto
+	protoc-c --c_out=. audit.proto
+
+audit.c: audit.pb-c.h
 
 OBJS_COMMON := \
 	event.o \
@@ -115,14 +118,8 @@ libcommon_full_systemd: $(OBJS_COMMON_FULL) sock-sd.o
 sock-sd.o: sock-sd.c
 	$(CC) -c $(LOCAL_CFLAGS) -DSYSTEMD $< -o $@
 
-ssl_util.o: ssl_util.c
-	$(CC) -c $(LOCAL_CFLAGS) $< -o $@
-
 %.o: %.c
 	$(CC) -c $(LOCAL_CFLAGS) $< -o $@
-
-audit.pb-c.c: audit.proto
-	protoc-c --c_out=. $<
 
 LFLAGS_TEST := \
 	-L. -lcommon_full \


### PR DESCRIPTION
This PR adapts the target dependencies for compilation of audit.proto in common/Makefile to ensure the 'protobuf' target actually provides audit.pb-c.{h,c}.

This fixes races during build:
make -C common protobuf
| make[1]: Entering directory /dir/service-static-1.0+999/common' | protoc-c --c_out=. audit.proto
| In file included from audit.c:28:
| audit.h:32:10: fatal error: audit.pb-c.h: No such file or directory
|    32 | #include "audit.pb-c.h"
|       |          ^~~~~~~~~~~~~~