### PR TITLE
Fix cleanup of network interfaces

### DIFF
--- a/common/ns.c
+++ b/common/ns.c
@@ -39,6 +39,7 @@
 #include "dir.h"
 #include "event.h"
 #include "file.h"
+#include "pidfd.h"
 #include "proc.h"
 #include "ns.h"
 
@@ -451,4 +452,24 @@ out:
 	mem_free0(ns_file1);
 	mem_free0(ns_file2);
 	return ret;
+}
+
+int
+ns_join_by_pid(pid_t pid, int nstype)
+{
+	int fd = pidfd_open(pid, 0);
+	if (fd == -1) {
+		ERROR_ERRNO("Could not open pidfd for pid %d", pid);
+		return -1;
+	}
+
+	if (setns(fd, nstype) == -1) {
+		ERROR_ERRNO("Could not join namespace by pidfd %d!", fd);
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+	INFO("Sucessfully joined ns of pid by pid: %d.", pid);
+	return 0;
 }

--- a/common/ns.h
+++ b/common/ns.h
@@ -122,4 +122,14 @@ ns_join_by_path(const char *ns_path);
 bool
 ns_cmp_pidns_by_pid(pid_t pid1, pid_t pid2);
 
+/**
+ * Join the namespace of process with given pid
+ *
+ * @param pid pid of process whose namespace will be joined
+ * @param nstype type of the namespace, as defined by CLONE_NEW* flags, see man(2) setns
+ * @return 0 if process successfully joined the namespace, -1 otherwise.
+ */
+int
+ns_join_by_pid(pid_t pid, int nstype);
+
 #endif //NS_H

--- a/common/pidfd.h
+++ b/common/pidfd.h
@@ -1,0 +1,88 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2025 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file pidfd.h
+ * This module provides wrappers for pidfd related syscalls
+ */
+
+#ifndef PIDFD_H
+#define PIDFD_H
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+// clang-format off
+#ifndef __NR_pidfd_open
+	#if defined __alpha__
+		#define __NR_pidfd_open 544
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32        /* o32 */
+			#define __NR_pidfd_open (434 + 4000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32       /* n32 */
+			#define __NR_pidfd_open (434 + 6000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64        /* n64 */
+			#define __NR_pidfd_open (434 + 5000)
+		#endif
+	#elif defined __ia64__
+		#define __NR_pidfd_open (434 + 1024)
+	#else
+		#define __NR_pidfd_open 434
+	#endif
+#endif
+#ifndef __NR_pidfd_getfd
+	#if defined __alpha__
+		#define __NR_pidfd_getfd 548
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32        /* o32 */
+			#define __NR_pidfd_getfd (438 + 4000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32       /* n32 */
+			#define __NR_pidfd_getfd (438 + 6000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64        /* n64 */
+			#define __NR_pidfd_getfd (438 + 5000)
+		#endif
+	#elif defined __ia64__
+		#define __NR_pidfd_getfd (438 + 1024)
+	#else
+		#define __NR_pidfd_getfd 438
+	#endif
+#endif
+// clang-format on
+
+inline int
+pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+inline int
+pidfd_getfd(int pidfd, int targetfd, unsigned int flags)
+{
+	return syscall(__NR_pidfd_getfd, pidfd, targetfd, flags);
+}
+
+#endif /* PIDFD_H */

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1431,7 +1431,7 @@ c_net_cleanup_phys(const c_net_t *net)
 		DEBUG("Renaming netifs in %s", container_get_name(net->container));
 
 		event_reset(); // reset event_loop of cloned from parent
-		if (ns_join_by_path(net->ns_path) < 0)
+		if (ns_join_by_pid(container_get_pid(net->container), CLONE_NEWNET) < 0)
 			FATAL_ERRNO("Could not join netns of compartment");
 
 		list_t *phys_ifaces = network_get_physical_interfaces_new();

--- a/daemon/c_seccomp/seccomp.c
+++ b/daemon/c_seccomp/seccomp.c
@@ -90,46 +90,6 @@
 #endif
 
 /**************************/
-
-#ifndef __NR_pidfd_open
-	#if defined __alpha__
-		#define __NR_pidfd_open 544
-	#elif defined _MIPS_SIM
-		#if _MIPS_SIM == _MIPS_SIM_ABI32        /* o32 */
-			#define __NR_pidfd_open (434 + 4000)
-		#endif
-		#if _MIPS_SIM == _MIPS_SIM_NABI32       /* n32 */
-			#define __NR_pidfd_open (434 + 6000)
-		#endif
-		#if _MIPS_SIM == _MIPS_SIM_ABI64        /* n64 */
-			#define __NR_pidfd_open (434 + 5000)
-		#endif
-	#elif defined __ia64__
-		#define __NR_pidfd_open (434 + 1024)
-	#else
-		#define __NR_pidfd_open 434
-	#endif
-#endif
-
-#ifndef __NR_pidfd_getfd
-	#if defined __alpha__
-		#define __NR_pidfd_getfd 548
-	#elif defined _MIPS_SIM
-		#if _MIPS_SIM == _MIPS_SIM_ABI32        /* o32 */
-			#define __NR_pidfd_getfd (438 + 4000)
-		#endif
-		#if _MIPS_SIM == _MIPS_SIM_NABI32       /* n32 */
-			#define __NR_pidfd_getfd (438 + 6000)
-		#endif
-		#if _MIPS_SIM == _MIPS_SIM_ABI64        /* n64 */
-			#define __NR_pidfd_getfd (438 + 5000)
-		#endif
-	#elif defined __ia64__
-		#define __NR_pidfd_getfd (438 + 1024)
-	#else
-		#define __NR_pidfd_getfd 438
-	#endif
-#endif
 // clang-format on
 
 #ifndef SYS_clock_settime
@@ -137,18 +97,6 @@
 #define SYS_clock_settime SYS_clock_settime64
 #endif
 #endif
-
-int
-pidfd_open(pid_t pid, unsigned int flags)
-{
-	return syscall(__NR_pidfd_open, pid, flags);
-}
-
-int
-pidfd_getfd(int pidfd, int targetfd, unsigned int flags)
-{
-	return syscall(__NR_pidfd_getfd, pidfd, targetfd, flags);
-}
 
 static int
 seccomp(unsigned int op, unsigned int flags, void *args)

--- a/daemon/c_seccomp/seccomp.h
+++ b/daemon/c_seccomp/seccomp.h
@@ -33,6 +33,7 @@
 #define SECCOMP_H
 
 #include <common/event.h>
+#include <common/pidfd.h>
 #include <linux/seccomp.h>
 
 typedef struct c_seccomp {
@@ -47,12 +48,6 @@ typedef struct c_seccomp {
 
 bool
 c_seccomp_capable(pid_t pid, uint64_t cap);
-
-int
-pidfd_open(pid_t pid, unsigned int flags);
-
-int
-pidfd_getfd(int pidfd, int targetfd, unsigned int flags);
 
 void *
 c_seccomp_fetch_vm_new(c_seccomp_t *seccomp, int pid, void *rbuf, uint64_t size);

--- a/scd/sc-hsm-lib/cardservice.h
+++ b/scd/sc-hsm-lib/cardservice.h
@@ -75,7 +75,7 @@ struct cardService *
 getSmartCardHSMCardService();
 #else
 static inline struct cardService *
-getSmartCardHSMCardService();
+getSmartCardHSMCardService()
 {
 	return NULL;
 }


### PR DESCRIPTION
* Address network interfaces with correct name, which we get from an id
* Join namespace by ID when removing network interface
* Remove wrong semicolon