### PR TITLE
daemon: Remove logs upon retrieval

### DIFF
--- a/common/logf.c
+++ b/common/logf.c
@@ -21,7 +21,7 @@
  * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
-#include "macro.h"
+#include "file.h"
 #include "logf.h"
 #include "list.h"
 #include "mem.h"
@@ -300,6 +300,8 @@ logf_file_new_name(const char *name)
 void *
 logf_file_new(const char *name)
 {
+	char *current = mem_printf("%s%s", name, ".current");
+
 	FILE *f;
 	char *name_with_time_of_day = logf_file_new_name(name);
 	f = fopen(name_with_time_of_day, "w");
@@ -312,6 +314,15 @@ logf_file_new(const char *name)
 		f = NULL;
 	}
 
+	if (file_exists(current) && unlink(current)) {
+		WARN_ERRNO("could not unlink %s", current);
+	}
+
+	if (symlink(name_with_time_of_day, current) < 0) {
+		WARN_ERRNO("Could not create symlink %s to %s", name_with_time_of_day, current);
+	}
+
+	mem_free0(current);
 	mem_free0(name_with_time_of_day);
 
 	return f;

--- a/common/logf.h
+++ b/common/logf.h
@@ -355,6 +355,20 @@ list_t *
 logf_get_current_log_files_new(const char *path);
 
 /**
+ * Apply the lock to the log folder.
+ * @param path The path to the log folder
+ */
+int
+logf_lock_apply(const char *path);
+
+/**
+ * Release the lock to the log folder.
+ * @param path The path to the log folder
+ */
+int
+logf_lock_release(const char *path, int lock_fd);
+
+/**
  * Deep free the log file list.
  * @param head The start of the linked list.
  */

--- a/common/logf.h
+++ b/common/logf.h
@@ -57,6 +57,8 @@
 #ifndef LOGF_H
 #define LOGF_H
 
+#include "list.h"
+
 typedef enum {
 	LOGF_PRIO_TRACE = 1,
 	LOGF_PRIO_DEBUG,
@@ -344,5 +346,19 @@ logf_klog_new(const char *name);
  */
 void
 logf_klog_write(logf_prio_t prio, const char *msg, void *data);
+
+/**
+ * Provides a list with currently used log files.
+ * @param path The path to the log folder.
+ */
+list_t *
+logf_get_current_log_files_new(const char *path);
+
+/**
+ * Deep free the log file list.
+ * @param head The start of the linked list.
+ */
+void
+logf_log_files_list_free(list_t *head);
 
 #endif /* LOGF_H */

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -210,6 +210,7 @@ message ControllerToDaemon {
 	optional bytes guestos_rootcert = 23;	// rootca certificate for local or new CAs to verify GuestOSes
 	optional string guestos_name = 24;	// name of a GuestOS (e.g. used in remove command)
 	optional bytes device_cert = 41;	// device cert for PUSH_DEVICE_CERT
+	optional bool remove_logs = 45 [ default = false ]; // remove logs after retrieval (except current log files)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Log files are removed upon successful retrieval. Except the currently used log files. This behavior is controllable by the caller of GET_LAST_LOG.