### PR TITLE
Updates default name of c0 to gyroidos-coreos

### DIFF
--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -33,7 +33,7 @@ message DeviceConfig {
 	// e.g. http://server:port/trustme/operatingsystems/<device>/<name>-<version>/<filename.img>
 
 	// configure os of the management container
-	optional string c0os = 7 [default = "trustx-coreos"];
+	optional string c0os = 7 [default = "gyroidos-coreos"];
 
 	// configure network
 	optional string host_addr = 8 [default = ""];


### PR DESCRIPTION
This PR fixes a startup issue where the c0 container fails to started since it is still named `trustx-coreos` instead of `gyroidos-coreos`, as expected by the cml. The PR updates c0’s default container name to address this issue.