### PR TITLE
daemon/c_user,cmld: Increase and refactor UID_MAX

### DIFF
--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -47,7 +47,7 @@
 
 #define UID_RANGE 100000
 #define UID_RANGES_START 100000
-#define UID_MAX 65535
+
 #define MAX_UID_RANGES ((int)((UINT_MAX - UID_RANGES_START) / UID_RANGE))
 
 /* Paths for controling mappings */

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -185,7 +185,6 @@ cmld_container_get_by_uuid(const uuid_t *uuid)
 	return NULL;
 }
 
-#define UID_MAX 65535
 container_t *
 cmld_container_get_by_uid(int uid)
 {

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -52,6 +52,8 @@
 
 #define CMLD_STORAGE_FREE_THRESHOLD 0.2 // 20% reserved space
 
+#define UID_MAX 65536
+
 /**
  * Enum represents different commands to control a container
  */


### PR DESCRIPTION
Refactor UID_MAX such that it is only defined in one location. Set value to 65536 to assure that also 65535 is mapped as id.

see https://github.com/systemd/systemd/blob/main/docs/UIDS-GIDS.md#considerations-for-container-managers