### PR TITLE
common/event: Always check timers after epoll

### DIFF
--- a/common/event.c
+++ b/common/event.c
@@ -413,7 +413,7 @@ event_epoll(int timeout)
 		if (errno == EINTR) // caused by suspend (no real error)
 			TRACE_ERRNO("epoll_wait interrupted by system");
 		else
-			DEBUG_ERRNO("epoll_wait failed");
+			ERROR_ERRNO("epoll_wait failed");
 
 	} else if (n > 0) {
 		for (i = 0; i < n; i++) {
@@ -851,8 +851,10 @@ event_loop(void)
 		event_signal_handler();
 
 		timeout = event_timeout();
-		if (!event_epoll(timeout))
-			event_timeout_handler();
+
+		event_epoll(timeout);
+
+		event_timeout_handler();
 
 		TRACE("Handled event");
 	}


### PR DESCRIPTION
This commit adapts the event loop implementation to always check whether timers expired regardless of whether epoll_wait returned pending io events.