### PR TITLE
treewide: Adapt to updated clang formatting

### DIFF
--- a/common/hex.c
+++ b/common/hex.c
@@ -47,10 +47,10 @@ convert_hex_to_bin(const char *in, size_t inlen, uint8_t *out, size_t outlen)
 	for (size_t i = 0; i < outlen; i++) {
 		if ((uint8_t)*pos < 0x30 || (uint8_t)*pos > 0x66 ||
 		    ((uint8_t)*pos > 0x39 && (uint8_t)*pos < 0x40) ||
-		    ((uint8_t)*pos > 0x46 && (uint8_t)*pos < 0x61) ||
-		    (uint8_t) * (pos + 1) < 0x30 || (uint8_t) * (pos + 1) > 0x66 ||
-		    ((uint8_t) * (pos + 1) > 0x39 && (uint8_t) * (pos + 1) < 0x40) ||
-		    ((uint8_t) * (pos + 1) > 0x46 && (uint8_t) * (pos + 1) < 0x61)) {
+		    ((uint8_t)*pos > 0x46 && (uint8_t)*pos < 0x61) || (uint8_t)*(pos + 1) < 0x30 ||
+		    (uint8_t)*(pos + 1) > 0x66 ||
+		    ((uint8_t)*(pos + 1) > 0x39 && (uint8_t)*(pos + 1) < 0x40) ||
+		    ((uint8_t)*(pos + 1) > 0x46 && (uint8_t)*(pos + 1) < 0x61)) {
 			return -3;
 		}
 		sscanf(pos, "%2hhx", &out[i]);

--- a/common/macro.h
+++ b/common/macro.h
@@ -765,7 +765,7 @@
 		}                                                                                  \
 	} while (0)
 
-#define HOURS_TO_MILLISECONDS(hours) ((hours)*60 * 60 * 1000)
+#define HOURS_TO_MILLISECONDS(hours) ((hours) * 60 * 60 * 1000)
 
 /**
  * Get the number of elements of an array.

--- a/common/munit.c
+++ b/common/munit.c
@@ -1426,14 +1426,9 @@ munit_test_runner_run_test_with_params(MunitTestRunner *runner, const MunitTest 
 				       const MunitParameter params[])
 {
 	MunitResult result = MUNIT_OK;
-	MunitReport report = {
-		0,
-		0,
-		0,
-		0,
+	MunitReport report = { 0, 0, 0, 0,
 #if defined(MUNIT_ENABLE_TIMING)
-		0,
-		0
+			       0, 0
 #endif
 	};
 	unsigned int output_l;

--- a/control/control.c
+++ b/control/control.c
@@ -290,7 +290,7 @@ main(int argc, char *argv[])
 	tcgetattr(STDIN_FILENO, &termios_before);
 
 	for (int c, option_index = 0;
-	     - 1 != (c = getopt_long(argc, argv, "+s:h", global_options, &option_index));) {
+	     -1 != (c = getopt_long(argc, argv, "+s:h", global_options, &option_index));) {
 		switch (c) {
 		case 's':
 			socket_file = optarg;
@@ -339,7 +339,7 @@ main(int argc, char *argv[])
 		int start_argc = argc - optind;
 		optind = 0; // reset optind to scan command-specific options
 		for (int c, option_index = 0;
-		     - 1 !=
+		     -1 !=
 		     (c = getopt_long(start_argc, start_argv, "r", log_options, &option_index));) {
 			switch (c) {
 			case 'r':
@@ -566,8 +566,8 @@ main(int argc, char *argv[])
 		int start_argc = argc - optind;
 		optind = 0; // reset optind to scan command-specific options
 		for (int c, option_index = 0;
-		     - 1 != (c = getopt_long(start_argc, start_argv, "k::s", start_options,
-					     &option_index));) {
+		     -1 != (c = getopt_long(start_argc, start_argv, "k::s", start_options,
+					    &option_index));) {
 			switch (c) {
 			case 'k':
 				container_start_params.key = optarg;
@@ -603,8 +603,8 @@ main(int argc, char *argv[])
 		int start_argc = argc - optind;
 		optind = 0; // reset optind to scan command-specific options
 		for (int c, option_index = 0;
-		     - 1 != (c = getopt_long(start_argc, start_argv, "k", start_options,
-					     &option_index));) {
+		     -1 != (c = getopt_long(start_argc, start_argv, "k", start_options,
+					    &option_index));) {
 			switch (c) {
 			case 'k':
 				container_start_params.key = optarg;
@@ -700,8 +700,8 @@ main(int argc, char *argv[])
 		int start_argc = argc - optind;
 		optind = 0; // reset optind to scan command-specific options
 		for (int c, option_index = 0;
-		     - 1 != (c = getopt_long(start_argc, start_argv, "i::p", assign_iface_options,
-					     &option_index));) {
+		     -1 != (c = getopt_long(start_argc, start_argv, "i::p", assign_iface_options,
+					    &option_index));) {
 			switch (c) {
 			case 'i':
 				assign_iface_params.iface_name = optarg;

--- a/converter/converter.c
+++ b/converter/converter.c
@@ -369,8 +369,8 @@ main(UNUSED int argc, char **argv)
 		image_arch = "amd64";
 		image_tag = "latest";
 		for (int c, option_index = 0;
-		     - 1 != (c = getopt_long(pull_argc, pull_argv, "t:r:a:", pull_options,
-					     &option_index));) {
+		     -1 != (c = getopt_long(pull_argc, pull_argv, "t:r:a:", pull_options,
+					    &option_index));) {
 			switch (c) {
 			case 'r':
 				url = optarg ? optarg : "registry-1.docker.io";
@@ -403,8 +403,8 @@ main(UNUSED int argc, char **argv)
 		const char *user = NULL;
 		const char *password = NULL;
 		for (int c, option_index = 0;
-		     - 1 != (c = getopt_long(login_argc, login_argv, ":r:u:p", login_options,
-					     &option_index));) {
+		     -1 != (c = getopt_long(login_argc, login_argv, ":r:u:p", login_options,
+					    &option_index));) {
 			switch (c) {
 			case 'r':
 				url = optarg;

--- a/daemon/bpf_insn.h
+++ b/daemon/bpf_insn.h
@@ -220,4 +220,4 @@ struct bpf_insn;
 			    .dst_reg = 0,                                                          \
 			    .src_reg = 0,                                                          \
 			    .off = 0,                                                              \
-			    .imm = ((FUNC)-BPF_FUNC_unspec) })
+			    .imm = ((FUNC) - BPF_FUNC_unspec) })

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -87,7 +87,7 @@ c_cap_set_current_process(void *capp)
 	/* 15 */ C_CAP_DROP(CAP_IPC_OWNER);
 	if (!(COMPARTMENT_FLAG_MODULE_LOAD & compartment_get_flags(cap->compartment)))
 		/* 16 */ C_CAP_DROP(CAP_SYS_MODULE);
-		///* 17 */ C_CAP_DROP(CAP_SYS_RAWIO); /* does NOT work */
+	///* 17 */ C_CAP_DROP(CAP_SYS_RAWIO); /* does NOT work */
 #ifndef DEBUG_BUILD
 	/* 19 */ C_CAP_DROP(CAP_SYS_PTRACE);
 #endif

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1169,7 +1169,7 @@ c_net_start_post_clone(void *netp)
 				if (network_setup_masquerading(ni->subnet, true))
 					FATAL_ERRNO("Could not setup masquerading for %s!",
 						    ni->veth_cmld_name);
-					// configuration of interface is done in root netns below
+				// configuration of interface is done in root netns below
 
 #ifdef DEBUG_BUILD
 				/* setup port forwarding for ssh in debug build */

--- a/rung/rung.c
+++ b/rung/rung.c
@@ -134,7 +134,7 @@ main(int argc, char *argv[])
 	int sock = 0;
 
 	for (int c, option_index = 1;
-	     - 1 != (c = getopt_long(argc, argv, "+s:r:l:f:h", global_options, &option_index));) {
+	     -1 != (c = getopt_long(argc, argv, "+s:r:l:f:h", global_options, &option_index));) {
 		switch (c) {
 		case 's':
 			socket_file = optarg;
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
 		if (optind >= argc)
 			print_usage(argv[0]);
 		for (int c, option_index = optind;
-		     - 1 !=
+		     -1 !=
 		     (c = getopt_long(argc, argv, "+b:p:c:h", create_options, &option_index));) {
 			switch (c) {
 			case 'b':
@@ -187,7 +187,7 @@ main(int argc, char *argv[])
 		if (optind >= argc)
 			print_usage(argv[0]);
 		for (int c, option_index = optind;
-		     - 1 != (c = getopt_long(argc, argv, "+f", delete_options, &option_index));) {
+		     -1 != (c = getopt_long(argc, argv, "+f", delete_options, &option_index));) {
 			switch (c) {
 			case 'f':
 				// fallthrough

--- a/tpm2_control/tpm2d_control.c
+++ b/tpm2_control/tpm2d_control.c
@@ -127,7 +127,7 @@ main(int argc, char *argv[])
 	bool has_response = false;
 	const char *socket_file = TPM2D_SOCKET;
 	for (int c, option_index = 0;
-	     - 1 != (c = getopt_long(argc, argv, "+s:h", global_options, &option_index));) {
+	     -1 != (c = getopt_long(argc, argv, "+s:h", global_options, &option_index));) {
 		switch (c) {
 		case 's':
 			socket_file = optarg;
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
 		int dm_argc = argc - optind;
 		optind = 0; // reset optind to scan command-specific options
 		for (int c, option_index = 0;
-		     - 1 !=
+		     -1 !=
 		     (c = getopt_long(dm_argc, dm_argv, "+l:", dmsetup_options, &option_index));) {
 			switch (c) {
 			case 'l':

--- a/tpm2d/tpm2d.c
+++ b/tpm2d/tpm2d.c
@@ -304,7 +304,7 @@ main(UNUSED int argc, char **argv)
 	logf_register(&logf_file_write, stdout);
 
 	for (int c, option_index = 0;
-	     - 1 != (c = getopt_long(argc, argv, ":snh", global_options, &option_index));) {
+	     -1 != (c = getopt_long(argc, argv, ":snh", global_options, &option_index));) {
 		switch (c) {
 		case 's':
 			use_simulator = true;


### PR DESCRIPTION
The clang version shippped with Debian Trixie comes with several formatting changes compared to the version shipped by Debian Bookworm. Therefore, the swich to Debian Trixie as base image for CI builds in gyroidos/gyroidos#79 makes integration of these formatting changes necessary.