### PR TITLE
Rework Network Interface Assignment Feature

### DIFF
--- a/common/network.c
+++ b/common/network.c
@@ -811,13 +811,24 @@ network_get_physical_interfaces_new()
 
 	IF_NULL_RETVAL_ERROR_ERRNO(if_ni, NULL);
 
-	list_t *if_name_list = NULL;
+	list_t *if_mac_list = NULL;
 
 	for (i = if_ni; i->if_index != 0 || i->if_name != NULL; i++) {
 		char *dev_drv_path = mem_printf("/sys/class/net/%s/device/driver", i->if_name);
 		if (file_exists(dev_drv_path) && i->if_name != NULL) {
-			DEBUG("Adding %s to the physical device list", i->if_name);
-			if_name_list = list_append(if_name_list, mem_strdup(i->if_name));
+			uint8_t mac[MAC_ADDR_LEN];
+			if (network_get_mac_by_ifname(i->if_name, mac) == 0) {
+				char *mac_str = network_mac_addr_to_str_new(mac);
+				DEBUG("Adding %s (mac: %s) to the physical device list", i->if_name,
+				      mac_str);
+				mem_free0(mac_str);
+				if_mac_list = list_append(if_mac_list,
+							  mem_memcpy((const unsigned char *)mac,
+								     MAC_ADDR_LEN));
+			} else {
+				WARN("Could not get MAC for physical interface %s, skipping",
+				     i->if_name);
+			}
 		} else if (file_exists(dev_drv_path)) {
 			DEBUG("Skipping unnamed network interface with index %d", i->if_index);
 		} else {
@@ -826,7 +837,7 @@ network_get_physical_interfaces_new()
 		mem_free0(dev_drv_path);
 	}
 	if_freenameindex(if_ni);
-	return if_name_list;
+	return if_mac_list;
 }
 
 /**

--- a/common/network.c
+++ b/common/network.c
@@ -635,6 +635,39 @@ network_delete_link(const char *dev)
 }
 
 void
+network_remove_all_altnames(const char *dev)
+{
+	ASSERT(dev);
+
+	char *command = mem_printf("%s -d link show dev %s", IP_PATH, dev);
+	FILE *fp = popen(command, "r");
+	mem_free0(command);
+
+	if (fp == NULL) {
+		WARN("Could not run ip link show for %s", dev);
+		return;
+	}
+
+	char *line = NULL;
+	size_t line_size = 0;
+	char altname[IFNAMSIZ];
+
+	while (getline(&line, &line_size, fp) != -1) {
+		if (sscanf(line, " altname %15s", altname) == 1) {
+			DEBUG("Removing altname %s from %s", altname, dev);
+			const char *const argv[] = { IP_PATH, "link",	 "property", "del", "dev",
+						     dev,     "altname", altname,    NULL };
+			if (proc_fork_and_execvp(argv)) {
+				WARN("Failed to remove altname %s from %s", altname, dev);
+			}
+		}
+	}
+
+	pclose(fp);
+	mem_free0(line);
+}
+
+void
 network_enable_ip_forwarding(void)
 {
 	// enable IP forwarding

--- a/common/network.c
+++ b/common/network.c
@@ -1053,7 +1053,7 @@ network_str_to_mac_addr(const char *mac_str, uint8_t mac[MAC_ADDR_LEN])
 }
 
 char *
-network_mac_addr_to_str_new(uint8_t mac[MAC_ADDR_LEN])
+network_mac_addr_to_str_new(const uint8_t mac[MAC_ADDR_LEN])
 {
 	return mem_printf("%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8
 			  ":%02" SCNx8,

--- a/common/network.c
+++ b/common/network.c
@@ -851,10 +851,10 @@ network_get_physical_interfaces_new()
 		if (file_exists(dev_drv_path) && i->if_name != NULL) {
 			uint8_t mac[MAC_ADDR_LEN];
 			if (network_get_mac_by_ifname(i->if_name, mac) == 0) {
-				char *mac_str = network_mac_addr_to_str_new(mac);
+				char mac_str[MAC_STR_LEN];
+				network_mac_addr_to_str(mac, mac_str);
 				DEBUG("Adding %s (mac: %s) to the physical device list", i->if_name,
 				      mac_str);
-				mem_free0(mac_str);
 				if_mac_list = list_append(if_mac_list,
 							  mem_memcpy((const unsigned char *)mac,
 								     MAC_ADDR_LEN));
@@ -1085,6 +1085,17 @@ network_str_to_mac_addr(const char *mac_str, uint8_t mac[MAC_ADDR_LEN])
 	return 0;
 }
 
+void
+network_mac_addr_to_str(const uint8_t mac[MAC_ADDR_LEN], char buf[MAC_STR_LEN])
+{
+	ASSERT(mac);
+	ASSERT(buf);
+
+	snprintf(buf, MAC_STR_LEN,
+		 "%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8,
+		 mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
 char *
 network_mac_addr_to_str_new(const uint8_t mac[MAC_ADDR_LEN])
 {
@@ -1165,12 +1176,11 @@ network_get_ifname_by_mac_in_ns_new(uint8_t mac[MAC_ADDR_LEN], pid_t pid)
 	IF_NULL_RETVAL(mac, NULL);
 	IF_TRUE_RETVAL(pid <= 0, NULL);
 
-	char *mac_str = network_mac_addr_to_str_new(mac);
-	IF_NULL_RETVAL(mac_str, NULL);
+	char mac_str[MAC_STR_LEN];
+	network_mac_addr_to_str(mac, mac_str);
 
 	list_t *link_list = NULL;
 	if (network_list_link_ns(pid, &link_list) < 0) {
-		mem_free0(mac_str);
 		return NULL;
 	}
 
@@ -1202,7 +1212,6 @@ network_get_ifname_by_mac_in_ns_new(uint8_t mac[MAC_ADDR_LEN], pid_t pid)
 	}
 
 	list_delete(link_list);
-	mem_free0(mac_str);
 
 	return ifname;
 }
@@ -1281,7 +1290,8 @@ network_phys_allow_mac(const char *chain, const char *netif, uint8_t mac[MAC_ADD
 {
 	ASSERT(netif);
 
-	char *mac_str = network_mac_addr_to_str_new(mac);
+	char mac_str[MAC_STR_LEN];
+	network_mac_addr_to_str(mac, mac_str);
 	const char *const argv[] = { IPTABLES_PATH, add ? "-I" : "-D",
 				     chain,	    "-m",
 				     "physdev",	    "--physdev-in",
@@ -1291,7 +1301,5 @@ network_phys_allow_mac(const char *chain, const char *netif, uint8_t mac[MAC_ADD
 				     "ACCEPT",	    NULL };
 
 	int ret = proc_fork_and_execvp(argv);
-
-	mem_free0(mac_str);
 	return ret;
 }

--- a/common/network.h
+++ b/common/network.h
@@ -38,6 +38,7 @@
 #include <net/if.h>
 
 #define MAC_ADDR_LEN 6
+#define MAC_STR_LEN 18
 
 /* Bionic misses this flag */
 #ifndef IFF_DOWN
@@ -267,6 +268,14 @@ network_remove_all_altnames(const char *dev);
  */
 int
 network_str_to_mac_addr(const char *mac_str, uint8_t mac[MAC_ADDR_LEN]);
+
+/**
+ * Writes a string representation of a mac address into the provided buffer.
+ * @param mac array to be converted
+ * @param buf buffer to write the string into (must be MAC_STR_LEN bytes)
+ */
+void
+network_mac_addr_to_str(const uint8_t mac[MAC_ADDR_LEN], char buf[MAC_STR_LEN]);
 
 /**
  * Constructs a String representation for a mac address.

--- a/common/network.h
+++ b/common/network.h
@@ -206,7 +206,9 @@ list_t *
 network_get_interfaces_new(void);
 
 /*
- * Generates a list containing names of all available physical network interfaces
+ * Generates a list containing MAC address strings of all available physical
+ * network interfaces. Each entry is a newly allocated string in the format
+ * "xx:xx:xx:xx:xx:xx".
  */
 list_t *
 network_get_physical_interfaces_new(void);
@@ -269,7 +271,7 @@ network_mac_addr_to_str_new(uint8_t mac[MAC_ADDR_LEN]);
  * Walk through sysfs to find the if name, e.g., shown by ip addr, to the corresponding
  * hardware (mac) address.
  * @param mac array containing the mac address
- * @return The name of the interface
+ * @return The name of the interface, NULL if not found.
  */
 char *
 network_get_ifname_by_addr_new(uint8_t mac[MAC_ADDR_LEN]);

--- a/common/network.h
+++ b/common/network.h
@@ -250,6 +250,15 @@ int
 network_rename_ifi(const char *old_ifi_name, const char *new_ifi_name);
 
 /**
+ * Remove all alternative names (altnames) from a network interface.
+ * Altnames persist across namespace transitions and can interfere with
+ * udev naming policies inside containers.
+ * @param dev The interface name.
+ */
+void
+network_remove_all_altnames(const char *dev);
+
+/**
  * Convert a String representing a mac address ,e.g., "00:11:22:33:44:55"
  * to the corresponding byte array.
  * @param mac_str String representing the mac

--- a/common/network.h
+++ b/common/network.h
@@ -265,7 +265,7 @@ network_str_to_mac_addr(const char *mac_str, uint8_t mac[MAC_ADDR_LEN]);
  * @return The string representing the mac, NULL on error
  */
 char *
-network_mac_addr_to_str_new(uint8_t mac[MAC_ADDR_LEN]);
+network_mac_addr_to_str_new(const uint8_t mac[MAC_ADDR_LEN]);
 
 /**
  * Walk through sysfs to find the if name, e.g., shown by ip addr, to the corresponding

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -676,6 +676,27 @@ c_net_unbridge_ifi(const char *if_name, list_t *mac_whitelist, const pid_t pid)
 	return 0;
 }
 
+static int
+c_net_resolve_mac_and_ifname_new(const char *if_name_mac, char **out_if_name,
+				 uint8_t out_mac[MAC_ADDR_LEN])
+{
+	ASSERT(if_name_mac);
+
+	if (network_str_to_mac_addr(if_name_mac, out_mac) == 0) {
+		*out_if_name = network_get_ifname_by_addr_new(out_mac);
+	} else {
+		*out_if_name = mem_strdup(if_name_mac);
+		if (network_get_mac_by_ifname(*out_if_name, out_mac) != 0) {
+			ERROR("Failed to get MAC for interface %s", *out_if_name);
+			mem_free0(*out_if_name);
+			*out_if_name = NULL;
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 /**
  * This function moves/bridges the network interface to the corresponding net
  * namespace of a container.
@@ -696,66 +717,54 @@ c_net_add_interface(void *netp, container_pnet_cfg_t *pnet_cfg)
 	bool c_net_internal = (NULL != list_find(net->pnet_mv_list, pnet_cfg));
 	pid_t pid = container_get_pid(net->container);
 
+	char *if_name = NULL;
 	uint8_t if_mac[MAC_ADDR_LEN];
-	char *if_name = (network_str_to_mac_addr(pnet_cfg->pnet_name, if_mac) != -1) ?
-				network_get_ifname_by_addr_new(if_mac) :
-				mem_strdup(pnet_cfg->pnet_name);
 
+	if (c_net_resolve_mac_and_ifname_new(pnet_cfg->pnet_name, &if_name, if_mac) != 0) {
+		WARN("Could not resolve interface for '%s'", pnet_cfg->pnet_name);
+		return -1;
+	}
 	IF_NULL_RETVAL(if_name, -1);
 
+	char *if_mac_str = network_mac_addr_to_str_new(if_mac);
+
 	if (!c_net_internal) {
-		IF_FALSE_GOTO_ERROR(cmld_netif_phys_remove_by_name(if_name), err);
+		IF_FALSE_GOTO_ERROR(cmld_netif_phys_remove_by_mac(if_mac), err);
 
 		// adding to c0, thus mark this interface available as free for others
 		if (cmld_containers_get_c0() == net->container) {
 			// re-add iface to list of available network interfaces
-			cmld_netif_phys_add_by_name(if_name);
+			cmld_netif_phys_add_by_mac(if_mac);
 		}
 	}
 
 	if (!pnet_cfg->mac_filter) { // directly map phys. IF into container
-		DEBUG("move phys %s to the ns of this pid: %d", pnet_cfg->pnet_name, pid);
+		DEBUG("move phys %s: %s to the ns of pid: %d", if_name, if_mac_str, pid);
 		IF_TRUE_GOTO_ERROR(-1 == c_net_move_ifi(if_name, pid), err);
 	} else { // pIF should be bridged and MAC filtering applied
-		DEBUG("bridge phys %s to the ns of this pid: %d", pnet_cfg->pnet_name, pid);
+		DEBUG("bridge phys %s: %s to the ns of pid: %d", if_name, if_mac_str, pid);
 		IF_TRUE_GOTO_ERROR(-1 == c_net_bridge_ifi(if_name, pnet_cfg->mac_whitelist, pid),
 				   err);
 	}
 
-	if (!c_net_internal) // called externally add to internal list
+	// always normalize pnet_name to MAC string for reliable MAC-based lookup
+	container_pnet_cfg_set_pnet_name(pnet_cfg, if_mac_str);
+
+	// called externally: add to internal list
+	if (!c_net_internal) {
 		net->pnet_mv_list = list_append(net->pnet_mv_list, pnet_cfg);
+	}
 
 	INFO("Sucessfully move/bridged iface %s to %s", if_name,
 	     container_get_name(net->container));
 
 	mem_free0(if_name);
+	mem_free0(if_mac_str);
 	return 0;
 err:
 	mem_free0(if_name);
+	mem_free0(if_mac_str);
 	return -1;
-}
-
-/**
- * Resolves a pnet_name (MAC string or kernel name) to the current kernel
- * interface name. First tries the root namespace, then falls back to
- * the given container namespace identified by pid.
- *
- * @return newly allocated interface name, or NULL if not found
- */
-static char *
-c_net_resolve_ifname_in_ns_new(const char *pnet_name, pid_t ns_pid)
-{
-	ASSERT(pnet_name);
-
-	uint8_t mac[MAC_ADDR_LEN];
-	if (network_str_to_mac_addr(pnet_name, mac) != -1) {
-		char *if_name = network_get_ifname_by_addr_new(mac);
-		if (!if_name && ns_pid > 0)
-			if_name = network_get_ifname_by_mac_in_ns_new(mac, ns_pid);
-		return if_name;
-	}
-
-	return NULL;
 }
 
 /**
@@ -772,25 +781,51 @@ c_net_remove_interface(void *netp, const char *if_name_mac)
 
 	container_pnet_cfg_t *cfg = NULL;
 	pid_t pid = container_get_pid(net->container);
+	char *if_name = NULL;
+	uint8_t if_mac[MAC_ADDR_LEN];
 
-	char *if_name = c_net_resolve_ifname_in_ns_new(if_name_mac, pid);
-	IF_NULL_RETVAL(if_name, -1);
-
-	for (list_t *l = net->pnet_mv_list; l; l = l->next) {
-		container_pnet_cfg_t *iter_cfg = l->data;
-		char *resolved_name = c_net_resolve_ifname_in_ns_new(iter_cfg->pnet_name, pid);
-
-		if (resolved_name && !strcmp(if_name, resolved_name)) {
-			cfg = iter_cfg;
-			mem_free0(resolved_name);
-			break;
+	if (network_str_to_mac_addr(if_name_mac, if_mac) == 0) {
+		// Input is a MAC string — lookup config by MAC
+		for (list_t *l = net->pnet_mv_list; l; l = l->next) {
+			container_pnet_cfg_t *_cfg = l->data;
+			uint8_t cfg_mac[MAC_ADDR_LEN];
+			if (network_str_to_mac_addr(_cfg->pnet_name, cfg_mac) == 0 &&
+			    0 == memcmp(if_mac, cfg_mac, MAC_ADDR_LEN)) {
+				cfg = _cfg;
+				break;
+			}
 		}
-		mem_free0(resolved_name);
+	} else {
+		// Input is a name — assumed to be the container-ns name
+		// Find config by resolving each config's MAC to a container-ns name
+		for (list_t *l = net->pnet_mv_list; l; l = l->next) {
+			container_pnet_cfg_t *_cfg = l->data;
+			uint8_t cfg_mac[MAC_ADDR_LEN];
+			if (network_str_to_mac_addr(_cfg->pnet_name, cfg_mac) != 0)
+				continue;
+			char *cfg_if_name = network_get_ifname_by_mac_in_ns_new(cfg_mac, pid);
+			if (!cfg_if_name)
+				continue;
+			if (!strcmp(cfg_if_name, if_name_mac)) {
+				cfg = _cfg;
+				memcpy(if_mac, cfg_mac, MAC_ADDR_LEN);
+				mem_free0(cfg_if_name);
+				break;
+			}
+			mem_free0(cfg_if_name);
+		}
 	}
 
-	if (NULL == cfg) {
-		mem_free0(if_name);
+	if (!cfg) {
+		TRACE("No config for interface %s found", if_name_mac);
 		return 0;
+	}
+
+	// Resolve container-ns name from MAC (works for both input types)
+	if_name = network_get_ifname_by_mac_in_ns_new(if_mac, pid);
+	if (!if_name) {
+		WARN("Could not resolve container-ns name for %s", if_name_mac);
+		return -1;
 	}
 
 	if (!cfg->mac_filter) { // remove directly mapped ifi
@@ -804,10 +839,11 @@ c_net_remove_interface(void *netp, const char *if_name_mac)
 	net->pnet_mv_list = list_remove(net->pnet_mv_list, cfg);
 	container_pnet_cfg_free(cfg);
 
-	cmld_netif_phys_add_by_name(if_name);
+	// add interface back to available phys list by MAC
+	cmld_netif_phys_add_by_mac(if_mac);
+
 	mem_free0(if_name);
 	return 0;
-
 err:
 	mem_free0(if_name);
 	return -1;
@@ -874,27 +910,21 @@ c_net_new(compartment_t *compartment)
 		// check if string is mac address
 		if (0 == network_str_to_mac_addr(if_name_macstr, mac)) {
 			TRACE("mv_name_list add if by mac: %s", if_name_macstr);
-
-			if (c0_is_up && (c0 != net->container)) {
-				if (!container_is_iface_in_config(c0, if_name_macstr)) {
-					INFO("Container created. Removing former implicitly assigned interface %s from core container",
-					     if_name_macstr);
-
-					container_remove_net_interface(c0, if_name_macstr);
-				}
-			}
-
 			// register at hotplug subsys
 			if (-1 == hotplug_register_netdev(net->container, pnet_cfg_mv)) {
 				WARN("Could not register Interface for moving");
 				container_pnet_cfg_free(pnet_cfg_mv);
 			} else {
-				INFO("Registed Interface for mac '%s' at hotplug subsys",
+				INFO("Registered Interface for mac '%s' at hotplug subsys",
 				     if_name_macstr);
 
 				net->hotplug_registered_mac_list =
 					list_append(net->hotplug_registered_mac_list,
 						    mem_memcpy((unsigned char *)&mac, sizeof(mac)));
+			}
+
+			if (c0_is_up && (c0 != net->container)) {
+				container_remove_net_interface(c0, if_name_macstr);
 			}
 
 			if_name = network_get_ifname_by_addr_new(mac);
@@ -910,7 +940,10 @@ c_net_new(compartment_t *compartment)
 
 		TRACE("mv_name_list add ifname %s", if_name);
 
-		if (cmld_netif_phys_remove_by_name(if_name))
+		// resolve MAC for phys list removal if pnet_name was a kernel name
+		mem_memset(&mac, 0, MAC_ADDR_LEN);
+		network_get_mac_by_ifname(if_name, mac);
+		if (cmld_netif_phys_remove_by_mac(mac))
 			net->pnet_mv_list = list_append(net->pnet_mv_list, pnet_cfg_mv);
 
 		mem_free0(if_name);
@@ -1130,11 +1163,14 @@ c_net_start_post_clone(void *netp)
 	pid_t pid = container_get_pid(net->container);
 	pid_t pid_c0 = cmld_containers_get_c0() ? container_get_pid(cmld_containers_get_c0()) : 0;
 
-	/* append list for c0 with available phys network interfaces */
+	/* append list for c0 with available phys network interfaces.
+	 * The phys list contains MAC byte arrays; convert to string for pnet_cfg. */
 	if (pid == pid_c0 && container_is_privileged(net->container)) {
 		for (list_t *l = cmld_get_netif_phys_list(); l; l = l->next) {
-			char *iff_name = l->data;
-			container_pnet_cfg_t *cfg = container_pnet_cfg_new(iff_name, false, NULL);
+			uint8_t *mac = l->data;
+			char *mac_str = network_mac_addr_to_str_new(mac);
+			container_pnet_cfg_t *cfg = container_pnet_cfg_new(mac_str, false, NULL);
+			mem_free0(mac_str);
 			net->pnet_mv_list = list_append(net->pnet_mv_list, cfg);
 		}
 	}

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1661,64 +1661,11 @@ c_net_join_netns(void *netp)
 	return 0;
 }
 
-/**
- * Move interfaces back to core container (c0) on destroy, but only if no
- * other service container has the interface in its config. If another
- * container claims it, leave it in root namespace so it can be picked up
- * directly when that container starts.
- */
-static void
-c_net_destroy(void *netp)
-{
-	c_net_t *net = netp;
-	ASSERT(net);
-
-	container_t *c0 = cmld_containers_get_c0();
-
-	bool c0_is_running = (c0 && container_is_stoppable(c0));
-	IF_FALSE_RETURN(c0_is_running && (net->container != c0));
-
-	list_t *pnet_list = container_get_pnet_cfg_list(net->container);
-	for (list_t *l = pnet_list; l; l = l->next) {
-		container_pnet_cfg_t *cfg = l->data;
-
-		/*
-		 * Check if another service container has this interface
-		 * in its config. If so, leave it in root ns.
-		 */
-		bool iface_explicitly_assigned = false;
-		for (int i = 0; i < cmld_containers_get_count(); i++) {
-			container_t *c = cmld_container_get_by_index(i);
-			if (c == net->container || c == c0)
-				continue;
-			if (container_is_iface_in_config(c, cfg->pnet_name)) {
-				iface_explicitly_assigned = true;
-				break;
-			}
-		}
-
-		if (iface_explicitly_assigned) {
-			INFO("Container destroyed. Interface %s claimed by another "
-			     "container, leaving in root namespace",
-			     cfg->pnet_name);
-			continue;
-		}
-
-		INFO("Container destroyed. Moving interface %s to core container", cfg->pnet_name);
-		container_pnet_cfg_t *c0_cfg = container_pnet_cfg_new(cfg->pnet_name, false, NULL);
-
-		if (container_add_net_interface(c0, c0_cfg) < 0) {
-			WARN("Failed to add interface %s to core container", cfg->pnet_name);
-			container_pnet_cfg_free(c0_cfg);
-		}
-	}
-}
-
 static compartment_module_t c_net_module = {
 	.name = MOD_NAME,
 	.compartment_new = c_net_new,
 	.compartment_free = c_net_free,
-	.compartment_destroy = c_net_destroy,
+	.compartment_destroy = NULL,
 	.start_post_clone_early = NULL,
 	.start_child_early = NULL,
 	.start_pre_clone = c_net_start_pre_clone,

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -531,9 +531,9 @@ c_net_mac_filter(const char *if_name, list_t *mac_whitelist, bool apply)
 		ret = network_phys_allow_mac("INPUT", if_name, mac, apply);
 		ret |= network_phys_allow_mac("FORWARD", if_name, mac, apply);
 		if (ret) {
-			char *mac_str = network_mac_addr_to_str_new(mac);
+			char mac_str[MAC_STR_LEN];
+			network_mac_addr_to_str(mac, mac_str);
 			ERROR("Failed to allow %s on %s", mac_str, if_name);
-			mem_free0(mac_str);
 			return -1;
 		}
 	}
@@ -726,7 +726,8 @@ c_net_add_interface(void *netp, container_pnet_cfg_t *pnet_cfg)
 	}
 	IF_NULL_RETVAL(if_name, -1);
 
-	char *if_mac_str = network_mac_addr_to_str_new(if_mac);
+	char if_mac_str[MAC_STR_LEN];
+	network_mac_addr_to_str(if_mac, if_mac_str);
 
 	if (!c_net_internal) {
 		IF_FALSE_GOTO_ERROR(cmld_netif_phys_remove_by_mac(if_mac), err);
@@ -759,11 +760,9 @@ c_net_add_interface(void *netp, container_pnet_cfg_t *pnet_cfg)
 	     container_get_name(net->container));
 
 	mem_free0(if_name);
-	mem_free0(if_mac_str);
 	return 0;
 err:
 	mem_free0(if_name);
-	mem_free0(if_mac_str);
 	return -1;
 }
 
@@ -1168,9 +1167,9 @@ c_net_start_post_clone(void *netp)
 	if (pid == pid_c0 && container_is_privileged(net->container)) {
 		for (list_t *l = cmld_get_netif_phys_list(); l; l = l->next) {
 			uint8_t *mac = l->data;
-			char *mac_str = network_mac_addr_to_str_new(mac);
+			char mac_str[MAC_STR_LEN];
+			network_mac_addr_to_str(mac, mac_str);
 			container_pnet_cfg_t *cfg = container_pnet_cfg_new(mac_str, false, NULL);
-			mem_free0(mac_str);
 			net->pnet_mv_list = list_append(net->pnet_mv_list, cfg);
 		}
 	}
@@ -1189,7 +1188,8 @@ c_net_start_post_clone(void *netp)
 	if (cmld_containers_get_c0() != net->container) {
 		for (list_t *l = net->hotplug_registered_mac_list; l; l = l->next) {
 			uint8_t *mac = l->data;
-			char *mac_str = network_mac_addr_to_str_new(mac);
+			char mac_str[MAC_STR_LEN];
+			network_mac_addr_to_str(mac, mac_str);
 
 			/* Skip if already claimed in pnet_mv_list */
 			bool already_claimed = false;
@@ -1200,10 +1200,8 @@ c_net_start_post_clone(void *netp)
 					break;
 				}
 			}
-			if (already_claimed) {
-				mem_free0(mac_str);
+			if (already_claimed)
 				continue;
-			}
 
 			/* Look up mac_filter/mac_whitelist from container config */
 			container_pnet_cfg_t *pnet_cfg = NULL;
@@ -1228,8 +1226,6 @@ c_net_start_post_clone(void *netp)
 				     mac_str);
 				container_pnet_cfg_free(pnet_cfg);
 			}
-
-			mem_free0(mac_str);
 		}
 	}
 

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1182,6 +1182,57 @@ c_net_start_post_clone(void *netp)
 			return -COMPARTMENT_ERROR_NET;
 	}
 
+	/* Retry claiming interfaces registered with hotplug but not added to
+	 * pnet_mv_list during c_net_new. This handles config update races where
+	 * the interface returns to root ns (and the phys list) after c_net_new
+	 * already ran but before the container starts. */
+	if (cmld_containers_get_c0() != net->container) {
+		for (list_t *l = net->hotplug_registered_mac_list; l; l = l->next) {
+			uint8_t *mac = l->data;
+			char *mac_str = network_mac_addr_to_str_new(mac);
+
+			/* Skip if already claimed in pnet_mv_list */
+			bool already_claimed = false;
+			for (list_t *m = net->pnet_mv_list; m; m = m->next) {
+				container_pnet_cfg_t *cfg = m->data;
+				if (!strcmp(cfg->pnet_name, mac_str)) {
+					already_claimed = true;
+					break;
+				}
+			}
+			if (already_claimed) {
+				mem_free0(mac_str);
+				continue;
+			}
+
+			/* Look up mac_filter/mac_whitelist from container config */
+			container_pnet_cfg_t *pnet_cfg = NULL;
+			for (list_t *cl = container_get_pnet_cfg_list(net->container); cl;
+			     cl = cl->next) {
+				container_pnet_cfg_t *orig = cl->data;
+				if (!strcmp(orig->pnet_name, mac_str)) {
+					pnet_cfg = container_pnet_cfg_new(mac_str, orig->mac_filter,
+									  orig->mac_whitelist);
+					break;
+				}
+			}
+			if (!pnet_cfg)
+				pnet_cfg = container_pnet_cfg_new(mac_str, false, NULL);
+
+			INFO("Retry claiming interface %s for container %s", mac_str,
+			     container_get_name(net->container));
+
+			if (c_net_add_interface(net, pnet_cfg) < 0) {
+				WARN("Could not claim interface %s during retry, "
+				     "may not be available yet",
+				     mac_str);
+				container_pnet_cfg_free(pnet_cfg);
+			}
+
+			mem_free0(mac_str);
+		}
+	}
+
 	// nothing to be configured
 	if (NULL == net->interface_list)
 		return 0;

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -2014,21 +2014,23 @@ cmld_guestos_delete(const char *guestos_name)
 }
 
 bool
-cmld_netif_phys_remove_by_name(const char *if_name)
+cmld_netif_phys_remove_by_mac(const uint8_t mac[MAC_ADDR_LEN])
 {
-	IF_NULL_RETVAL(if_name, false);
+	IF_NULL_RETVAL(mac, false);
 
 	list_t *found = NULL;
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
-		char *cmld_if_name = l->data;
-		if (0 == strcmp(if_name, cmld_if_name)) {
+		uint8_t *entry_mac = l->data;
+		if (0 == memcmp(mac, entry_mac, MAC_ADDR_LEN)) {
 			found = l;
-			mem_free0(cmld_if_name);
 			break;
 		}
 	}
 	if (found) {
-		INFO("Removing '%s' from global available physical netifs", if_name);
+		char *mac_str = network_mac_addr_to_str_new(mac);
+		INFO("Removing '%s' from global available physical netifs", mac_str);
+		mem_free0(mac_str);
+		mem_free0(found->data);
 		cmld_netif_phys_list = list_unlink(cmld_netif_phys_list, found);
 		return true;
 	}
@@ -2036,18 +2038,21 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 }
 
 void
-cmld_netif_phys_add_by_name(const char *if_name)
+cmld_netif_phys_add_by_mac(const uint8_t mac[MAC_ADDR_LEN])
 {
-	IF_NULL_RETURN(if_name);
-	INFO("Adding '%s' to global available physical netifs", if_name);
+	IF_NULL_RETURN(mac);
 
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
-		char *cmld_if_name = l->data;
-		if (0 == strcmp(if_name, cmld_if_name)) {
+		uint8_t *entry_mac = l->data;
+		if (0 == memcmp(mac, entry_mac, MAC_ADDR_LEN)) {
 			return;
 		}
 	}
-	cmld_netif_phys_list = list_append(cmld_netif_phys_list, mem_strdup(if_name));
+	char *mac_str = network_mac_addr_to_str_new(mac);
+	INFO("Adding '%s' to global available physical netifs", mac_str);
+	mem_free0(mac_str);
+	cmld_netif_phys_list = list_append(cmld_netif_phys_list,
+					   mem_memcpy((const unsigned char *)mac, MAC_ADDR_LEN));
 }
 
 void
@@ -2078,8 +2083,8 @@ cmld_cleanup(void)
 		mem_free0(cmld_shared_data_dir);
 
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
-		char *name = l->data;
-		mem_free0(name);
+		uint8_t *mac = l->data;
+		mem_free0(mac);
 	}
 	list_delete(cmld_netif_phys_list);
 }

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -2027,9 +2027,9 @@ cmld_netif_phys_remove_by_mac(const uint8_t mac[MAC_ADDR_LEN])
 		}
 	}
 	if (found) {
-		char *mac_str = network_mac_addr_to_str_new(mac);
+		char mac_str[MAC_STR_LEN];
+		network_mac_addr_to_str(mac, mac_str);
 		INFO("Removing '%s' from global available physical netifs", mac_str);
-		mem_free0(mac_str);
 		mem_free0(found->data);
 		cmld_netif_phys_list = list_unlink(cmld_netif_phys_list, found);
 		return true;
@@ -2048,9 +2048,9 @@ cmld_netif_phys_add_by_mac(const uint8_t mac[MAC_ADDR_LEN])
 			return;
 		}
 	}
-	char *mac_str = network_mac_addr_to_str_new(mac);
+	char mac_str[MAC_STR_LEN];
+	network_mac_addr_to_str(mac, mac_str);
 	INFO("Adding '%s' to global available physical netifs", mac_str);
-	mem_free0(mac_str);
 	cmld_netif_phys_list = list_append(cmld_netif_phys_list,
 					   mem_memcpy((const unsigned char *)mac, MAC_ADDR_LEN));
 }

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -584,33 +584,18 @@ cmld_container_config_sync_cb(container_t *container, container_callback_t *cb, 
 		return;
 	}
 
-	/* Config file may have been deleted by cmld_container_destroy_cb
-	 * which fired before us on the same state transition.
-	 */
-	if (!file_exists(container_get_config_filename(container))) {
-		DEBUG("Config file removed, skipping reload for %s",
-		      container_get_description(container));
-		container_unregister_observer(container, cb);
-		return;
-	}
-
 	// in error case reload may destroy container object thus dup uuid
 	uuid_t *c_uuid = uuid_new(uuid_string(container_get_uuid(container)));
 
 	container_unregister_observer(container, cb);
 	DEBUG("Container is out of sync with its config. Reloading..");
 
-	container_t *new_container = cmld_reload_container(c_uuid, cmld_get_containers_dir());
-
-	if (!new_container) {
+	if (!cmld_reload_container(c_uuid, cmld_get_containers_dir())) {
 		ERROR("Failed to reload container on config update");
 		audit_log_event(c_uuid, FSA, CMLD, CONTAINER_MGMT, "reload", uuid_string(c_uuid),
 				0);
 		if (strncmp(uuid_string(c_uuid), CMLD_C0_UUID, strlen(CMLD_C0_UUID)))
 			FATAL("Could not reload C0!");
-	} else {
-		container_update_pnet_cfg_list(container,
-					       container_get_pnet_cfg_list(new_container));
 	}
 
 	mem_free0(c_uuid);
@@ -2108,23 +2093,6 @@ cmld_container_has_token_changed(container_t *container, container_config_t *con
 					   container_config_get_usbtoken_serial(conf));
 }
 
-static void
-cmld_handle_config_netif_removal(container_t *container, container_config_t *config)
-{
-	list_t *new_pnet_cfg_list = container_config_get_net_ifaces_list_new(config);
-
-	bool service_container_is_up = container_is_stoppable(container);
-
-	if (!service_container_is_up) {
-		container_update_pnet_cfg_list(container, new_pnet_cfg_list);
-	}
-
-	for (list_t *l = new_pnet_cfg_list; l; l = l->next) {
-		container_pnet_cfg_free(l->data);
-	}
-	list_delete(new_pnet_cfg_list);
-}
-
 int
 cmld_update_config(container_t *container, uint8_t *buf, size_t buf_len, uint8_t *sig_buf,
 		   size_t sig_len, uint8_t *cert_buf, size_t cert_len)
@@ -2153,8 +2121,6 @@ cmld_update_config(container_t *container, uint8_t *buf, size_t buf_len, uint8_t
 
 	ret = container_config_write(conf);
 	container_set_sync_state(container, false);
-
-	cmld_handle_config_netif_removal(container, conf);
 
 	// Wipe container if USB token serial changed
 	if (cmld_container_has_token_changed(container, conf)) {

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -570,6 +570,9 @@ cmld_containers_add(container_t *container)
 	cmld_containers_list = list_append(cmld_containers_list, container);
 }
 
+static container_t *
+cmld_reload_container_internal(const uuid_t *uuid, const char *path, container_callback_t *cb);
+
 /*
  * This callback handles config updates during container start/stop cycle
  */
@@ -590,7 +593,7 @@ cmld_container_config_sync_cb(container_t *container, container_callback_t *cb, 
 	container_unregister_observer(container, cb);
 	DEBUG("Container is out of sync with its config. Reloading..");
 
-	if (!cmld_reload_container(c_uuid, cmld_get_containers_dir())) {
+	if (!cmld_reload_container_internal(c_uuid, cmld_get_containers_dir(), cb)) {
 		ERROR("Failed to reload container on config update");
 		audit_log_event(c_uuid, FSA, CMLD, CONTAINER_MGMT, "reload", uuid_string(c_uuid),
 				0);
@@ -610,8 +613,8 @@ cmld_container_delayed_free(void *data)
 	container_free(container);
 }
 
-container_t *
-cmld_reload_container(const uuid_t *uuid, const char *path)
+static container_t *
+cmld_reload_container_internal(const uuid_t *uuid, const char *path, container_callback_t *cb)
 {
 	ASSERT(uuid);
 	ASSERT(path);
@@ -643,8 +646,13 @@ cmld_reload_container(const uuid_t *uuid, const char *path)
 		      container_get_name(c_current));
 
 		cmld_containers_list = list_remove(cmld_containers_list, c_current);
-		// delayed free to allow all observers to finish up
-		container_finish_observers(c_current, cmld_container_delayed_free, c_current);
+		if (cb) {
+			// delayed free to allow all observers to finish up
+			container_finish_observers(c_current, cmld_container_delayed_free,
+						   c_current);
+		} else {
+			container_free(c_current);
+		}
 	}
 
 	DEBUG("Loaded config for container %s", container_get_name(c));
@@ -666,6 +674,12 @@ cleanup:
 	mem_free0(uuid_tmp);
 
 	return c;
+}
+
+container_t *
+cmld_reload_container(const uuid_t *uuid, const char *path)
+{
+	return cmld_reload_container_internal(uuid, path, NULL);
 }
 
 static int

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -312,34 +312,36 @@ cmld_guestos_delete(const char *guestos_name);
 
 /**
  * Returns the list of currently available physical network interfaces
- * not occupied by an application container. Used to assign theses
- * interfaces to c0 in case of c0 uses a private network namespace.
+ * not occupied by an application container, as MAC address byte arrays.
+ * Used to assign these interfaces to c0 in case of c0 uses a private
+ * network namespace.
  */
 list_t *
 cmld_get_netif_phys_list(void);
 
 /**
- * Removes the interface from cmld's list of available physical network
- * interfaces. This is used during container config phases, where network
- * interfaces are assigned directly to a container. The remaining physical
- * interfaces are then assigned to the first privileged container with a
- * private network namespace (usually c0).
+ * Removes the interface identified by MAC address string from cmld's
+ * list of available physical network interfaces. This is used during
+ * container config phases, where network interfaces are assigned
+ * directly to a container. The remaining physical interfaces are then
+ * assigned to the first privileged container with a private network
+ * namespace (usually c0).
  *
- * @param if_name name of the interface which should be removed.
+ * @param mac MAC address byte array.
  * @return true if iface was available and removed, false otherwise.
  */
 bool
-cmld_netif_phys_remove_by_name(const char *if_name);
+cmld_netif_phys_remove_by_mac(const uint8_t mac[MAC_ADDR_LEN]);
 
 /**
- * Adds the given interface to cmld's list of available physical network
- * interfaces. This is used during runtime if a container releases its
- * assignment.
+ * Adds the given interface identified by MAC address to cmld's
+ * list of available physical network interfaces. This is used during
+ * runtime if a container releases its assignment.
  *
- * @param if_name name of the interface which should be added.
+ * @param mac MAC address byte array.
  */
 void
-cmld_netif_phys_add_by_name(const char *if_name);
+cmld_netif_phys_add_by_mac(const uint8_t mac[MAC_ADDR_LEN]);
 
 /*
  * Reboot device by trying to gracfully stop or killing containers otherwise.

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -690,22 +690,6 @@ container_destroy(container_t *container)
 	return ret;
 }
 
-bool
-container_is_iface_in_config(const container_t *container, const char *pnet_name)
-{
-	ASSERT(container);
-	ASSERT(pnet_name);
-
-	for (list_t *l = container->pnet_cfg_list; l; l = l->next) {
-		container_pnet_cfg_t *cfg = l->data;
-
-		if (strcmp(cfg->pnet_name, pnet_name) == 0)
-			return true;
-	}
-
-	return false;
-}
-
 const char *
 container_get_config_filename(const container_t *container)
 {

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -30,7 +30,6 @@
 #include "common/dir.h"
 #include "common/uuid.h"
 #include "compartment.h"
-#include "cmld.h"
 
 #include <limits.h>
 #include <stdbool.h>
@@ -705,48 +704,6 @@ container_is_iface_in_config(const container_t *container, const char *pnet_name
 	}
 
 	return false;
-}
-
-void
-container_update_pnet_cfg_list(container_t *container, list_t *new_pnet_cfg_list)
-{
-	ASSERT(container);
-
-	container_t *c0 = cmld_containers_get_c0();
-
-	if (!c0 || !container_is_stoppable(c0))
-		return;
-
-	/*
-	 * Find interfaces REMOVED from config (in old but not in new list).
-	 * These become unassigned and should move to core container as implicit.
-	 */
-	for (list_t *l = container->pnet_cfg_list; l; l = l->next) {
-		container_pnet_cfg_t *old_cfg = l->data;
-
-		bool found = false;
-		for (list_t *n = new_pnet_cfg_list; n; n = n->next) {
-			container_pnet_cfg_t *new_cfg = n->data;
-			if (strcmp(old_cfg->pnet_name, new_cfg->pnet_name) == 0) {
-				found = true;
-				break;
-			}
-		}
-
-		if (found)
-			continue;
-
-		INFO("Service container updated. Moving interface %s to core container",
-		     old_cfg->pnet_name);
-
-		container_pnet_cfg_t *c0_cfg =
-			container_pnet_cfg_new(old_cfg->pnet_name, false, NULL);
-
-		if (container_add_net_interface(c0, c0_cfg) < 0) {
-			WARN("Failed to add interface %s to core container", c0_cfg->pnet_name);
-			container_pnet_cfg_free(c0_cfg);
-		}
-	}
 }
 
 const char *

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -195,11 +195,6 @@ bool
 container_images_dir_contains_image(const container_t *container);
 
 /**
- * Return true if the network interface is in the container configuration.
- */
-bool
-container_is_iface_in_config(const container_t *container, const char *pnet_name);
-/**
  * Get the container config filename.
  */
 const char *

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -199,13 +199,6 @@ container_images_dir_contains_image(const container_t *container);
  */
 bool
 container_is_iface_in_config(const container_t *container, const char *pnet_name);
-
-/**
- * Assigns former explicitly assigned network interfaces implicitly to core container.
- */
-void
-container_update_pnet_cfg_list(container_t *container, list_t *new_pnet_cfg_list);
-
 /**
  * Get the container config filename.
  */

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -398,7 +398,7 @@ error:
 	if (newevent)
 		mem_free0(newevent);
 	if (pnet_cfg_c0)
-		mem_free0(pnet_cfg_c0);
+		container_pnet_cfg_free(pnet_cfg_c0);
 	return -1;
 }
 

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -607,6 +607,7 @@ hotplug_unregister_netdev(container_t *container, uint8_t mac[MAC_ADDR_LEN])
 	 */
 	char *if_name = network_get_ifname_by_addr_new(mac);
 	if (if_name) {
+		cmld_netif_phys_add_by_mac(mac);
 		char *uevent_path = mem_printf("/sys/class/net/%s/uevent", if_name);
 		if (file_exists(uevent_path)) {
 			if (-1 == file_printf(uevent_path, "add")) {

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -191,6 +191,7 @@ hotplug_rename_ifi_new(const char *oldname, const char *infix)
 		if (known_name) {
 			if (!strcmp(oldname, known_name)) {
 				DEBUG("Keeping ifname %s", oldname);
+				network_remove_all_altnames(oldname);
 				return mem_strdup(oldname);
 			}
 
@@ -200,6 +201,7 @@ hotplug_rename_ifi_new(const char *oldname, const char *infix)
 				return NULL;
 			}
 
+			network_remove_all_altnames(known_name);
 			return mem_strdup(known_name);
 		}
 	}
@@ -207,6 +209,7 @@ hotplug_rename_ifi_new(const char *oldname, const char *infix)
 	// do not rename twice (new interface already with cml prefix)
 	if (!strncmp(oldname, "cml", 3)) {
 		DEBUG("Keeping ifname %s", oldname);
+		network_remove_all_altnames(oldname);
 		return mem_strdup(oldname);
 	}
 
@@ -228,6 +231,7 @@ hotplug_rename_ifi_new(const char *oldname, const char *infix)
 		return NULL;
 	}
 
+	network_remove_all_altnames(newname);
 	return newname;
 }
 

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -463,5 +463,26 @@ hotplug_unregister_netdev(container_t *container, uint8_t mac[MAC_ADDR_LEN])
 	hotplug_container_netdev_mapping_free(mapping_to_remove);
 	mem_free0(macstr);
 
+	/*
+	 * If the NIC is in root ns, add to phys available list synchronously and
+	 * trigger a uevent so it gets reassigned (e.g., to c0).
+	 * The synchronous add is needed because during config updates, the
+	 * replacement container's c_net_start_post_clone may run before the
+	 * retriggered uevent is processed by the event loop.
+	 */
+	char *if_name = network_get_ifname_by_addr_new(mac);
+	if (if_name) {
+		char *uevent_path = mem_printf("/sys/class/net/%s/uevent", if_name);
+		if (file_exists(uevent_path)) {
+			if (-1 == file_printf(uevent_path, "add")) {
+				WARN("Could not retrigger uevent for %s", if_name);
+			} else {
+				DEBUG("Retriggered uevent for unregistered netdev %s", if_name);
+			}
+		}
+		mem_free0(uevent_path);
+		mem_free0(if_name);
+	}
+
 	return 0;
 }

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -49,6 +49,72 @@ typedef struct hotplug_net_dev_mapping {
 	uint8_t mac[MAC_ADDR_LEN];
 } hotplug_container_netdev_mapping_t;
 
+/**
+ * Persistent MAC → original kernel name mapping.
+ * Entries are never removed, so the original name survives container
+ * assignment/unassignment cycles where the interface may be renamed.
+ */
+typedef struct {
+	uint8_t mac[MAC_ADDR_LEN];
+	char *ifname;
+} hotplug_netif_name_t;
+
+static list_t *hotplug_known_names_list = NULL;
+
+static hotplug_netif_name_t *
+hotplug_netif_name_new(const uint8_t mac[MAC_ADDR_LEN], const char *ifname)
+{
+	hotplug_netif_name_t *entry = mem_new0(hotplug_netif_name_t, 1);
+	memcpy(entry->mac, mac, MAC_ADDR_LEN);
+	entry->ifname = mem_strdup(ifname);
+	return entry;
+}
+
+static void
+hotplug_netif_name_free(hotplug_netif_name_t *entry)
+{
+	IF_NULL_RETURN(entry);
+	if (entry->ifname)
+		mem_free0(entry->ifname);
+	mem_free0(entry);
+}
+
+static void
+hotplug_register_name(const uint8_t mac[MAC_ADDR_LEN], const char *ifname)
+{
+	IF_NULL_RETURN(mac);
+	IF_NULL_RETURN(ifname);
+
+	// Only store the first name seen for a given MAC
+	for (list_t *l = hotplug_known_names_list; l; l = l->next) {
+		hotplug_netif_name_t *entry = l->data;
+		if (0 == memcmp(mac, entry->mac, MAC_ADDR_LEN))
+			return;
+	}
+
+	hotplug_netif_name_t *entry = hotplug_netif_name_new(mac, ifname);
+
+	char *mac_str = network_mac_addr_to_str_new(mac);
+	DEBUG("Registered persistent name '%s' for MAC %s", ifname, mac_str);
+	mem_free0(mac_str);
+
+	hotplug_known_names_list = list_append(hotplug_known_names_list, entry);
+}
+
+static const char *
+hotplug_get_ifname_by_mac(const uint8_t mac[MAC_ADDR_LEN])
+{
+	IF_NULL_RETVAL(mac, NULL);
+
+	for (list_t *l = hotplug_known_names_list; l; l = l->next) {
+		hotplug_netif_name_t *entry = l->data;
+		if (0 == memcmp(mac, entry->mac, MAC_ADDR_LEN))
+			return entry->ifname;
+	}
+
+	return NULL;
+}
+
 static uevent_uev_t *uevent_uev = NULL;
 
 // track net devices mapped to containers
@@ -110,17 +176,41 @@ hotplug_rename_ifi_new(const char *oldname, const char *infix)
 	static unsigned int cmld_wlan_idx = 0;
 	static unsigned int cmld_eth_idx = 0;
 
-	//generate interface name that is unique
-	//in the root network namespace
 	unsigned int *ifi_idx;
 	char *newname = NULL;
 
-	// do not rename twice
+	/*
+	 * Check if this interface has a known name from a previous assignment.
+	 * This handles interfaces returning from containers (which may have
+	 * renamed them) or from cleanup (which uses cml-prefixed collision names).
+	 */
+	uint8_t mac[MAC_ADDR_LEN];
+	if (network_get_mac_by_ifname(oldname, mac) == 0) {
+		const char *known_name = hotplug_get_ifname_by_mac(mac);
+
+		if (known_name) {
+			if (!strcmp(oldname, known_name)) {
+				DEBUG("Keeping ifname %s", oldname);
+				return mem_strdup(oldname);
+			}
+
+			INFO("Restoring known name %s for %s", known_name, oldname);
+			if (network_rename_ifi(oldname, known_name)) {
+				ERROR("Failed to restore name %s for %s", known_name, oldname);
+				return NULL;
+			}
+
+			return mem_strdup(known_name);
+		}
+	}
+
+	// do not rename twice (new interface already with cml prefix)
 	if (!strncmp(oldname, "cml", 3)) {
 		DEBUG("Keeping ifname %s", oldname);
 		return mem_strdup(oldname);
 	}
 
+	// New interface: assign next sequential cml name
 	ifi_idx = !strcmp(infix, "wlan") ? &cmld_wlan_idx : &cmld_eth_idx;
 
 	if (-1 == asprintf(&newname, "%s%s%d", "cml", infix, *ifi_idx)) {
@@ -164,9 +254,11 @@ hotplug_rename_interface(const uevent_event_t *event)
 		goto err;
 	}
 
-	// replace ifname in cmld's available netifs
-	if (cmld_netif_phys_remove_by_name(event_ifname))
-		cmld_netif_phys_add_by_name(new_ifname);
+	// Register the cml-prefixed name as the persistent original name
+	uint8_t rename_mac[MAC_ADDR_LEN];
+	if (network_get_mac_by_ifname(new_ifname, rename_mac) == 0) {
+		hotplug_register_name(rename_mac, new_ifname);
+	}
 
 	new_devpath = hotplug_replace_devpath_new(event_devpath, event_ifname, new_ifname);
 
@@ -223,6 +315,8 @@ hotplug_netdev_move(uevent_event_t *event)
 		goto error;
 	}
 
+	macstr = network_mac_addr_to_str_new(iface_mac);
+
 	container_t *container = NULL;
 	container_pnet_cfg_t *pnet_cfg = NULL;
 	for (list_t *l = hotplug_container_netdev_mapping_list; l; l = l->next) {
@@ -234,11 +328,26 @@ hotplug_netdev_move(uevent_event_t *event)
 		}
 	}
 
-	// no mapping found move to c0
+	// no mapping found move to c0, use MAC string as pnet_name
+	// This ways c0's pnet_mv_list stays valid even if c0's OS renames the interface
 	if (!container) {
 		container = cmld_containers_get_c0();
-		pnet_cfg_c0 = container_pnet_cfg_new(event_ifname, false, NULL);
+		pnet_cfg_c0 = container_pnet_cfg_new(macstr, false, NULL);
 		pnet_cfg = pnet_cfg_c0;
+	}
+
+	// Rename interface before any early-out — ensures returning interfaces
+	// get their original name restored even if the target container isn't running yet
+	DEBUG("Renaming new interface we were notified about");
+	newevent = hotplug_rename_interface(event);
+
+	// uevent pointer is not freed inside this function, therefore we can safely drop it
+	if (newevent) {
+		DEBUG("using renamed uevent");
+		event = newevent;
+		event_ifname = uevent_event_get_interface(event);
+	} else {
+		WARN("failed to rename interface %s. injecting uevent as it is", event_ifname);
 	}
 
 	if (!container) {
@@ -252,20 +361,6 @@ hotplug_netdev_move(uevent_event_t *event)
 		WARN("Target container '%s' is not running, skip moving %s",
 		     container_get_description(container), event_ifname);
 		goto error;
-	}
-
-	// rename network interface to avoid name clashes when moving to container
-	DEBUG("Renaming new interface we were notified about");
-	newevent = hotplug_rename_interface(event);
-
-	// uevent pointer is not freed inside this function, therefore we can safely drop it
-	if (newevent) {
-		DEBUG("using renamed uevent");
-		event = newevent;
-		event_ifname = uevent_event_get_interface(event);
-		container_pnet_cfg_set_pnet_name(pnet_cfg, event_ifname);
-	} else {
-		WARN("failed to rename interface %s. injecting uevent as it is", event_ifname);
 	}
 
 	macstr = network_mac_addr_to_str_new(iface_mac);
@@ -334,8 +429,33 @@ hotplug_handle_uevent_cb(unsigned actions, uevent_event_t *event, UNUSED void *d
 	/* move network ifaces to containers */
 	if (actions & UEVENT_ACTION_ADD && !strcmp(uevent_event_get_subsystem(event), "net") &&
 	    !strstr(uevent_event_get_devpath(event), "virtual")) {
-		// got new physical interface, initially add to cmld tracking list
-		cmld_netif_phys_add_by_name(uevent_event_get_interface(event));
+		char *if_name = uevent_event_get_interface(event);
+
+		bool found = false;
+		for (list_t *l = hotplug_container_netdev_mapping_list; l; l = l->next) {
+			hotplug_container_netdev_mapping_t *mapping = l->data;
+			char *registered_if_name = network_get_ifname_by_addr_new(mapping->mac);
+
+			// Interface may be inside a container's netns and not visible
+			if (registered_if_name) {
+				if (!strcmp(if_name, registered_if_name)) {
+					found = true;
+					DEBUG("Found a hotplug mapping for netif: %s. Won't add to physical list",
+					      registered_if_name);
+					mem_free0(registered_if_name);
+					break;
+				}
+				mem_free0(registered_if_name);
+			}
+		}
+
+		if (!found) {
+			// got new physical interface, initially add to cmld tracking list
+			uint8_t new_mac[MAC_ADDR_LEN];
+			if (network_get_mac_by_ifname(if_name, new_mac) == 0) {
+				cmld_netif_phys_add_by_mac(new_mac);
+			}
+		}
 
 		// give sysfs some time to settle if iface is wifi
 		event_timer_t *e =
@@ -357,10 +477,14 @@ hotplug_trigger_net_uevent_foreach_cb(const char *path, const char *name, UNUSED
 		goto out;
 	}
 
-	// if already in list just do 'nothing' (check removes ifname, so just readd)
-	if (cmld_netif_phys_remove_by_name(name)) {
-		cmld_netif_phys_add_by_name(name);
-		goto out;
+	// if already in list just do 'nothing' (check by MAC address)
+	uint8_t check_mac[MAC_ADDR_LEN];
+	if (network_get_mac_by_ifname(name, check_mac) == 0) {
+		bool already_tracked = cmld_netif_phys_remove_by_mac(check_mac);
+		if (already_tracked) {
+			cmld_netif_phys_add_by_mac(check_mac);
+			goto out;
+		}
 	}
 
 	if (-1 == file_printf(uevent_path, "add")) {
@@ -380,14 +504,20 @@ hotplug_init()
 {
 	if (!cmld_is_hostedmode_active()) {
 		// Initially rename all physical interfaces before starting uevent handling.
+		// The phys list contains MAC byte arrays; resolve to kernel name for rename.
 		for (list_t *l = cmld_get_netif_phys_list(); l; l = l->next) {
-			const char *ifname = l->data;
+			uint8_t *mac = l->data;
+			char *ifname = network_get_ifname_by_addr_new(mac);
+			if (!ifname)
+				continue;
 			const char *prefix = (network_interface_is_wifi(ifname)) ? "wlan" : "eth";
 			char *if_name_new = hotplug_rename_ifi_new(ifname, prefix);
+			// Register the cml-prefixed name as the persistent original name
 			if (if_name_new) {
-				mem_free0(l->data);
-				l->data = if_name_new;
+				hotplug_register_name(mac, if_name_new);
+				mem_free0(if_name_new);
 			}
+			mem_free0(ifname);
 		}
 	}
 
@@ -416,6 +546,11 @@ hotplug_cleanup()
 
 	uevent_remove_uev(uevent_uev);
 	uevent_uev_free(uevent_uev);
+
+	for (list_t *l = hotplug_known_names_list; l; l = l->next) {
+		hotplug_netif_name_free(l->data);
+	}
+	list_delete(hotplug_known_names_list);
 }
 
 int

--- a/daemon/hotplug.c
+++ b/daemon/hotplug.c
@@ -94,9 +94,9 @@ hotplug_register_name(const uint8_t mac[MAC_ADDR_LEN], const char *ifname)
 
 	hotplug_netif_name_t *entry = hotplug_netif_name_new(mac, ifname);
 
-	char *mac_str = network_mac_addr_to_str_new(mac);
+	char mac_str[MAC_STR_LEN];
+	network_mac_addr_to_str(mac, mac_str);
 	DEBUG("Registered persistent name '%s' for MAC %s", ifname, mac_str);
-	mem_free0(mac_str);
 
 	hotplug_known_names_list = list_append(hotplug_known_names_list, entry);
 }
@@ -309,7 +309,7 @@ static int
 hotplug_netdev_move(uevent_event_t *event)
 {
 	uint8_t iface_mac[MAC_ADDR_LEN];
-	char *macstr = NULL;
+	char macstr[MAC_STR_LEN];
 	uevent_event_t *newevent = NULL;
 	container_pnet_cfg_t *pnet_cfg_c0 = NULL;
 	char *event_ifname = uevent_event_get_interface(event);
@@ -319,7 +319,7 @@ hotplug_netdev_move(uevent_event_t *event)
 		goto error;
 	}
 
-	macstr = network_mac_addr_to_str_new(iface_mac);
+	network_mac_addr_to_str(iface_mac, macstr);
 
 	container_t *container = NULL;
 	container_pnet_cfg_t *pnet_cfg = NULL;
@@ -367,7 +367,6 @@ hotplug_netdev_move(uevent_event_t *event)
 		goto error;
 	}
 
-	macstr = network_mac_addr_to_str_new(iface_mac);
 	if (cmld_container_add_net_iface(container, pnet_cfg, false)) {
 		ERROR("cannot move '%s' to %s!", macstr, container_get_name(container));
 		goto error;
@@ -394,14 +393,12 @@ hotplug_netdev_move(uevent_event_t *event)
 out:
 	if (newevent)
 		mem_free0(newevent);
-	mem_free0(macstr);
 	return 0;
 error:
 	if (newevent)
 		mem_free0(newevent);
 	if (pnet_cfg_c0)
 		mem_free0(pnet_cfg_c0);
-	mem_free0(macstr);
 	return -1;
 }
 
@@ -567,12 +564,11 @@ hotplug_register_netdev(container_t *container, container_pnet_cfg_t *pnet_cfg)
 
 	hotplug_container_netdev_mapping_list =
 		list_append(hotplug_container_netdev_mapping_list, mapping);
-	char *macstr = network_mac_addr_to_str_new(mapping->mac);
+	char macstr[MAC_STR_LEN];
+	network_mac_addr_to_str(mapping->mac, macstr);
 
 	INFO("Registered netdev '%s' for container %s", macstr,
 	     container_get_name(mapping->container));
-
-	mem_free0(macstr);
 	return 0;
 }
 
@@ -594,13 +590,13 @@ hotplug_unregister_netdev(container_t *container, uint8_t mac[MAC_ADDR_LEN])
 	hotplug_container_netdev_mapping_list =
 		list_remove(hotplug_container_netdev_mapping_list, mapping_to_remove);
 
-	char *macstr = network_mac_addr_to_str_new(mapping_to_remove->mac);
+	char macstr[MAC_STR_LEN];
+	network_mac_addr_to_str(mapping_to_remove->mac, macstr);
 
 	INFO("Unregistered netdev '%s' for container %s", macstr,
 	     container_get_name(mapping_to_remove->container));
 
 	hotplug_container_netdev_mapping_free(mapping_to_remove);
-	mem_free0(macstr);
 
 	/*
 	 * If the NIC is in root ns, add to phys available list synchronously and


### PR DESCRIPTION
I recognized that the hotplug subsystem can be used to do the network interface assignments transparently. The feature was reworked and fits way better into the architecture, than the first attempt, I think.