### PR TITLE
common/list: Fix list_join

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -51,6 +51,7 @@ list_join(list_t *list, list_t *list_append)
 
 	list_t *l_tail = list_tail(list);
 	l_tail->next = list_append;
+	list_append->prev = l_tail;
 
 	return list;
 }


### PR DESCRIPTION
Experimentation with CBMC [1] on selected libcommon modules revealed that list_join breaks the doubly linked list forgetting to set the prev pointer.

[1] https://github.com/diffblue/cbmc