### PR TITLE
Jenkinsfile: Do not bind an agent for the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-	agent any
+	agent none
 
 	options {
 		preserveStashes(buildCount: 1) 


### PR DESCRIPTION
Currently, this pipeline hogs an agent for handling the pipeline itself.
The pipeline does not contain any tasks that need to run on an agent,
thereby, it can be handled by the Jenkins controller.
We free this agent, thereby moving handling into the controller.