### PR TITLE
daemon/audit.c: prevent endless epoll loop on netlink socket error

### DIFF
--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -771,6 +771,11 @@ audit_cb_kernel_handle_log(int fd, unsigned events, UNUSED event_io_t *io, void 
 	char *log_record = NULL;
 
 	if (events & EVENT_IO_EXCEPT) {
+		WARN("EVENT_IO_EXCEPT on audit socket %d, draining pending error.", fd);
+	    int err = 0;
+	    socklen_t errlen = sizeof(err);
+	    getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen);
+	    WARN("Audit socket error: %s", strerror(err));
 		goto out;
 	}
 


### PR DESCRIPTION
After updating the kernel to 6.18+,
the audit netlink socket triggers an EPOLLERR event.

Currently, if an EVENT_IO_EXCEPT happens,
the function audit_cb_kernel_handle_log
goes to the out label, which clears the buffer
without reading from the socket.
This way, the EPOLLERR event is never cleared
and is always triggered again.
The continuous memory allocation
and freeing is causing high CPU Usage.

To solve this problem,
the socket will be read
and the error printed as WARN.
This breaks the epoll loop.