### PR TITLE
Leak fixes

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -40,6 +40,7 @@
 #include <alloca.h>
 #include <sys/sendfile.h>
 #include <errno.h>
+#include <stdint.h>
 
 /******************************************************************************/
 
@@ -509,7 +510,9 @@ file_disk_space_available(const char *path, off_t required, float threshold)
 	min_free_space *= threshold;
 
 	if (required > available || (available - required) < min_free_space) {
-		ERROR("Not enough disk space left");
+		ERROR("Not enough disk space left, required: %jd, "
+		      "available: %jd, min_free_space, %jd, threshold: %f",
+		      (intmax_t)required, (intmax_t)available, (intmax_t)min_free_space, threshold);
 		return false;
 	}
 

--- a/common/macro.h
+++ b/common/macro.h
@@ -786,6 +786,21 @@
 #define INIT __attribute__((constructor))
 
 /**
+ * Indicates that a function is executed in destructor context after main
+ * (or exit()) returns, in reverse order of construction. Paired with INIT
+ * for symmetric module-level setup and teardown.
+ */
+#define DEINIT __attribute__((destructor))
+
+/**
+ * Like DEINIT, but pinned to the lowest user-allowed destructor priority
+ * (101) so the function fires last among all DEINIT/destructor handlers.
+ * Use this for teardown that must outlive every other DEINIT, e.g.
+ * closing log handlers used by the rest of the destructor chain.
+ */
+#define DEINIT_LAST __attribute__((destructor(101)))
+
+/**
  * Helper macro to cast a function pointer to a void pointer.
  */
 #ifdef __GNUC__

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -78,6 +78,9 @@ uint64_t AUDIT_STORAGE = 0;
 
 static AUDIT_MODE LOGMODE = CONTAINER;
 
+static nl_sock_t *audit_sock = NULL;
+static event_io_t *audit_io_event = NULL;
+
 typedef struct {
 	char *key;
 	char *value;
@@ -901,7 +904,6 @@ audit_init(uint32_t size)
 	TRACE("Initializing audit subsystem");
 
 	/* Open audit netlink socket */
-	nl_sock_t *audit_sock;
 	if (!(audit_sock = nl_sock_default_new(NETLINK_AUDIT))) {
 		ERROR("Failed to allocate audit netlink socket");
 		return -1;
@@ -911,19 +913,38 @@ audit_init(uint32_t size)
 	if (-1 == audit_kernel_send(audit_sock, AUDIT_SET, &s_pid, sizeof(struct audit_status))) {
 		ERROR("Failed to set cmld as auditd in kernel!");
 		nl_sock_free(audit_sock);
+		audit_sock = NULL;
 		return -1;
 	}
 
-	event_io_t *audit_io_event = event_io_new(nl_sock_get_fd(audit_sock), EVENT_IO_READ,
-						  &audit_cb_kernel_handle_log, audit_sock);
+	audit_io_event = event_io_new(nl_sock_get_fd(audit_sock), EVENT_IO_READ,
+				      &audit_cb_kernel_handle_log, audit_sock);
 	event_add_io(audit_io_event);
 
 	/* Register message handler for audit logs */
 	if (fd_make_non_blocking(nl_sock_get_fd(audit_sock))) {
 		ERROR("Could not set fd of audit netlink socket to non blocking!");
+		event_remove_io(audit_io_event);
+		event_io_free(audit_io_event);
+		audit_io_event = NULL;
 		nl_sock_free(audit_sock);
+		audit_sock = NULL;
 		return -1;
 	}
 
 	return 0;
+}
+
+void
+audit_cleanup(void)
+{
+	if (audit_io_event) {
+		event_remove_io(audit_io_event);
+		event_io_free(audit_io_event);
+		audit_io_event = NULL;
+	}
+	if (audit_sock) {
+		nl_sock_free(audit_sock);
+		audit_sock = NULL;
+	}
 }

--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -54,4 +54,7 @@ audit_process_ack(const container_t *audit, const char *ack);
 int
 audit_init(uint32_t size);
 
+void
+audit_cleanup(void);
+
 #endif /* AUDIT_H */

--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -225,3 +225,16 @@ c_audit_init(void)
 	container_register_audit_get_loginuid_handler(MOD_NAME, c_audit_get_loginuid);
 	container_register_audit_set_loginuid_handler(MOD_NAME, c_audit_set_loginuid);
 }
+
+static void DEINIT
+c_audit_deinit(void)
+{
+	container_unregister_audit_get_last_ack_handler();
+	container_unregister_audit_set_last_ack_handler();
+	container_unregister_audit_get_processing_ack_handler();
+	container_unregister_audit_set_processing_ack_handler();
+	container_unregister_audit_get_loginuid_handler();
+	container_unregister_audit_set_loginuid_handler();
+
+	container_unregister_compartment_module(&c_audit_module);
+}

--- a/daemon/c_automount.c
+++ b/daemon/c_automount.c
@@ -281,3 +281,9 @@ c_automount_init(void)
 	// register this module in container.c
 	container_register_compartment_module(&c_automount_module);
 }
+
+static void DEINIT
+c_automount_deinit(void)
+{
+	container_unregister_compartment_module(&c_automount_module);
+}

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -166,3 +166,11 @@ c_cap_init(void)
 	// register relevant handlers implemented by this module
 	container_register_set_cap_current_process_handler(MOD_NAME, c_cap_set_current_process);
 }
+
+static void DEINIT
+c_cap_deinit(void)
+{
+	container_unregister_set_cap_current_process_handler();
+
+	container_unregister_compartment_module(&c_cap_module);
+}

--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -1321,9 +1321,18 @@ static compartment_module_t c_cgroups_module = {
 	.join_ns = NULL,
 };
 
-static void
+static void DEINIT
 c_cgroups_deinit(void)
 {
+	container_unregister_freeze_handler();
+	container_unregister_unfreeze_handler();
+	container_unregister_device_allow_handler();
+	container_unregister_device_deny_handler();
+	container_unregister_is_device_allowed_handler();
+	container_unregister_add_pid_to_cgroups_handler();
+
+	container_unregister_compartment_module(&c_cgroups_module);
+
 	/*
 	 * per-entry data is mem_new0'd by c_cgroups_list_add() and is owned
 	 * by the global lists. Free each item before releasing the list nodes.
@@ -1356,10 +1365,6 @@ c_cgroups_init(void)
 	container_register_device_deny_handler(MOD_NAME, c_cgroups_devices_dev_deny);
 	container_register_is_device_allowed_handler(MOD_NAME, c_cgroups_devices_is_dev_allowed);
 	container_register_add_pid_to_cgroups_handler(MOD_NAME, c_cgroups_add_pid);
-
-	// register cleanup on exit handler
-	if (atexit(&c_cgroups_deinit))
-		WARN("Could not register on exit deinit method 'c_cgroups_deinit()'");
 
 	// mount cgroups if not allready mounted by init
 	if (mount_cgroups(get_active_cgroups_subsystems()))

--- a/daemon/c_cgroups_dev.c
+++ b/daemon/c_cgroups_dev.c
@@ -823,6 +823,9 @@ c_cgroups_dev_free(void *cgroups_devp)
 	c_cgroups_dev_t *cgroups_dev = cgroups_devp;
 	ASSERT(cgroups_dev);
 
+	if (cgroups_dev->path)
+		mem_free0(cgroups_dev->path);
+
 	mem_free0(cgroups_dev);
 }
 

--- a/daemon/c_cgroups_dev.c
+++ b/daemon/c_cgroups_dev.c
@@ -1059,9 +1059,16 @@ static compartment_module_t c_cgroups_dev_module = {
 	.join_ns = NULL,
 };
 
-static void
+static void DEINIT
 c_cgroups_dev_deinit(void)
 {
+	container_unregister_device_allow_handler();
+	container_unregister_device_deny_handler();
+	container_unregister_device_set_access_handler();
+	container_unregister_is_device_allowed_handler();
+
+	container_unregister_compartment_module(&c_cgroups_dev_module);
+
 	/*
 	 * per-entry data is mem_new0'd by c_cgroups_dev_list_add() and is
 	 * owned by the global lists. Free each item before releasing the
@@ -1093,8 +1100,4 @@ c_cgroups_dev_init(void)
 	container_register_device_deny_handler(MOD_NAME, c_cgroups_dev_device_deny);
 	container_register_device_set_access_handler(MOD_NAME, c_cgroups_dev_device_set_access);
 	container_register_is_device_allowed_handler(MOD_NAME, c_cgroups_dev_is_dev_allowed);
-
-	// register cleanup on exit handler
-	if (atexit(&c_cgroups_dev_deinit))
-		WARN("Could not register on exit deinit method 'c_cgroups_dev_deinit()'");
 }

--- a/daemon/c_cgroups_sockopt.c
+++ b/daemon/c_cgroups_sockopt.c
@@ -332,3 +332,9 @@ c_cgroups_sockopt_init(void)
 	// register this module in container.c
 	container_register_compartment_module(&c_cgroups_sockopt_module);
 }
+
+static void DEINIT
+c_cgroups_sockopt_deinit(void)
+{
+	container_unregister_compartment_module(&c_cgroups_sockopt_module);
+}

--- a/daemon/c_cgroups_v2.c
+++ b/daemon/c_cgroups_v2.c
@@ -667,9 +667,15 @@ static compartment_module_t c_cgroups_module = {
 	.join_ns = NULL,
 };
 
-void
+DEINIT static void
 c_cgroups_deinit(void)
 {
+	container_unregister_add_pid_to_cgroups_handler();
+	container_unregister_freeze_handler();
+	container_unregister_unfreeze_handler();
+
+	container_unregister_compartment_module(&c_cgroups_module);
+
 	// free global memory alloctaions
 	if (c_cgroups_subtree)
 		mem_free0(c_cgroups_subtree);
@@ -685,10 +691,6 @@ c_cgroups_init(void)
 	container_register_add_pid_to_cgroups_handler(MOD_NAME, c_cgroups_add_pid);
 	container_register_freeze_handler(MOD_NAME, c_cgroups_freeze);
 	container_register_unfreeze_handler(MOD_NAME, c_cgroups_unfreeze);
-
-	// register cleanup on exit handler
-	if (atexit(&c_cgroups_deinit))
-		WARN("Could not register on exit deinit method 'c_cgroups_deinit()'");
 
 	// mount cgroups if not already mounted by init
 	if (!file_is_mountpoint(CGROUPS_FOLDER)) {

--- a/daemon/c_fifo.c
+++ b/daemon/c_fifo.c
@@ -488,9 +488,11 @@ static compartment_module_t c_fifo_module = {
 	.join_ns = NULL,
 };
 
-static void
+static void DEINIT
 c_fifo_deinit(void)
 {
+	container_unregister_compartment_module(&c_fifo_module);
+
 	/*
 	 * per-entry data pointers are borrowed from each container's fifo_list
 	 * and not owned by c0_fifo_list, so only the list nodes need releasing.
@@ -504,8 +506,4 @@ c_fifo_init(void)
 {
 	// register this module in container.c
 	container_register_compartment_module(&c_fifo_module);
-
-	// register cleanup on exit handler
-	if (atexit(&c_fifo_deinit))
-		WARN("Could not register on exit deinit method 'c_fifo_deinit()'");
 }

--- a/daemon/c_hotplug.c
+++ b/daemon/c_hotplug.c
@@ -740,9 +740,11 @@ static compartment_module_t c_hotplug_module = {
 	.join_ns = NULL,
 };
 
-static void
+static void DEINIT
 c_hotplug_deinit(void)
 {
+	container_unregister_compartment_module(&c_hotplug_module);
+
 	/*
 	 * per-entry data pointers are borrowed from each container's usbdev_list
 	 * and not owned by c_hotplug_token_list, so only the list nodes need releasing.
@@ -756,8 +758,4 @@ c_hotplug_init(void)
 {
 	// register this module in container.c
 	container_register_compartment_module(&c_hotplug_module);
-
-	// register cleanup on exit handler
-	if (atexit(&c_hotplug_deinit))
-		WARN("Could not register on exit deinit method 'c_hotplug_deinit()'");
 }

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -664,3 +664,11 @@ c_idmapped_init(void)
 	// register relevant handlers implemented by this module
 	container_register_shift_ids_handler(MOD_NAME, c_idmapped_shift_ids);
 }
+
+static void DEINIT
+c_idmapped_deinit(void)
+{
+	container_unregister_shift_ids_handler();
+
+	container_unregister_compartment_module(&c_idmapped_module);
+}

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1778,3 +1778,13 @@ c_net_init(void)
 	container_register_get_vnet_runtime_cfg_new_handler(MOD_NAME,
 							    c_net_get_interface_mapping_new);
 }
+
+static void DEINIT
+c_net_deinit(void)
+{
+	container_unregister_add_net_interface_handler();
+	container_unregister_remove_net_interface_handler();
+	container_unregister_get_vnet_runtime_cfg_new_handler();
+
+	container_unregister_compartment_module(&c_net_module);
+}

--- a/daemon/c_oci.c
+++ b/daemon/c_oci.c
@@ -195,3 +195,9 @@ c_oci_init(void)
 	// register this module in container.c
 	container_register_compartment_module(&c_oci_module);
 }
+
+static void DEINIT
+c_oci_deinit(void)
+{
+	container_unregister_compartment_module(&c_oci_module);
+}

--- a/daemon/c_run.c
+++ b/daemon/c_run.c
@@ -717,3 +717,13 @@ c_run_init(void)
 	container_register_write_exec_input_handler(MOD_NAME, c_run_write_exec_input);
 	container_register_get_console_sock_cmld_handler(MOD_NAME, c_run_get_console_sock_cmld);
 }
+
+static void DEINIT
+c_run_deinit(void)
+{
+	container_unregister_run_handler();
+	container_unregister_write_exec_input_handler();
+	container_unregister_get_console_sock_cmld_handler();
+
+	container_unregister_compartment_module(&c_run_module);
+}

--- a/daemon/c_seccomp/seccomp.c
+++ b/daemon/c_seccomp/seccomp.c
@@ -641,3 +641,9 @@ c_seccomp_init(void)
 	// register this module in container.c
 	container_register_compartment_module(&c_seccomp_module);
 }
+
+static void DEINIT
+c_seccomp_deinit(void)
+{
+	container_unregister_compartment_module(&c_seccomp_module);
+}

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -522,3 +522,13 @@ c_service_init(void)
 	container_register_audit_record_notify_handler(MOD_NAME, c_service_audit_notify);
 	container_register_audit_notify_complete_handler(MOD_NAME, c_service_audit_notify_complete);
 }
+
+static void DEINIT
+c_service_deinit(void)
+{
+	container_unregister_audit_record_send_handler();
+	container_unregister_audit_record_notify_handler();
+	container_unregister_audit_notify_complete_handler();
+
+	container_unregister_compartment_module(&c_service_module);
+}

--- a/daemon/c_smartcard.c
+++ b/daemon/c_smartcard.c
@@ -1352,3 +1352,18 @@ c_smartcard_init(void)
 	container_register_has_token_changed_handler(MOD_NAME, c_smartcard_has_token_changed);
 	container_register_scd_connect_handler(MOD_NAME, c_smartcard_scd_connect);
 }
+
+static void DEINIT
+c_smartcard_deinit(void)
+{
+	container_unregister_ctrl_with_smartcard_handler();
+	container_unregister_set_smartcard_error_cb_handler();
+	container_unregister_change_pin_handler();
+	container_unregister_scd_release_pairing_handler();
+	container_unregister_token_attach_handler();
+	container_unregister_token_detach_handler();
+	container_unregister_has_token_changed_handler();
+	container_unregister_scd_connect_handler();
+
+	container_unregister_compartment_module(&c_smartcard_module);
+}

--- a/daemon/c_time.c
+++ b/daemon/c_time.c
@@ -292,3 +292,12 @@ c_time_init(void)
 	container_register_get_creation_time_handler(MOD_NAME, c_time_get_creation_time);
 	container_register_get_uptime_handler(MOD_NAME, c_time_get_uptime);
 }
+
+static void DEINIT
+c_time_deinit(void)
+{
+	container_unregister_get_creation_time_handler();
+	container_unregister_get_uptime_handler();
+
+	container_unregister_compartment_module(&c_time_module);
+}

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -489,3 +489,13 @@ c_user_init(void)
 	container_register_get_uid_handler(MOD_NAME, c_user_get_uid);
 	container_register_open_userns_handler(MOD_NAME, c_user_open_userns);
 }
+
+static void DEINIT
+c_user_deinit(void)
+{
+	container_unregister_setuid0_handler();
+	container_unregister_get_uid_handler();
+	container_unregister_open_userns_handler();
+
+	container_unregister_compartment_module(&c_user_module);
+}

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -2090,3 +2090,14 @@ c_vol_init(void)
 	container_register_is_encrypted_handler(MOD_NAME, c_vol_is_encrypted);
 	container_register_get_cryptfs_mode_handler(MOD_NAME, c_vol_get_mode);
 }
+
+static void DEINIT
+c_vol_deinit(void)
+{
+	container_unregister_get_rootdir_handler();
+	container_unregister_get_mnt_handler();
+	container_unregister_is_encrypted_handler();
+	container_unregister_get_cryptfs_mode_handler();
+
+	container_unregister_compartment_module(&c_vol_module);
+}

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1098,6 +1098,7 @@ c_vol_cleanup_dm(c_vol_t *vol)
 		char *type = dm_get_target_type_new(fd, label);
 		if (type == NULL) {
 			WARN("Failed to get target type of %s\n", label);
+			mem_free0(label);
 			continue;
 		}
 

--- a/daemon/c_xorg_compat.c
+++ b/daemon/c_xorg_compat.c
@@ -165,3 +165,9 @@ c_xorg_compat_init(void)
 	// register this module in container.c
 	container_register_compartment_module(&c_xorg_compat_module);
 }
+
+static void DEINIT
+c_xorg_compat_deinit(void)
+{
+	container_unregister_compartment_module(&c_xorg_compat_module);
+}

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1568,10 +1568,13 @@ cmld_init_stage_unit(const char *path)
 		a_b_update_init();
 
 	// init audit and set max audit log file size
-	if (audit_init(device_config_get_audit_size(device_config)) < 0)
+	if (audit_init(device_config_get_audit_size(device_config)) < 0) {
 		WARN("Could not init audit module");
-	else
+	} else {
 		INFO("audit initialized.");
+		if (atexit(&audit_cleanup))
+			WARN("Could not register on exit cleanup method 'audit_cleanup()'");
+	}
 
 	if (time_init() < 0)
 		FATAL("Could not init time module");

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -110,7 +110,7 @@
 
 static const char *cmld_path = DEFAULT_BASE_PATH;
 static char *cmld_container_path = NULL;
-static const char *cmld_wrapped_keys_path = NULL;
+static char *cmld_wrapped_keys_path = NULL;
 
 static list_t *cmld_containers_list = NULL; // usually first element is c0
 static list_t *cmld_units_list = NULL;
@@ -2079,6 +2079,9 @@ cmld_cleanup(void)
 
 	if (cmld_container_path)
 		mem_free0(cmld_container_path);
+
+	if (cmld_wrapped_keys_path)
+		mem_free0(cmld_wrapped_keys_path);
 
 	if (cmld_device_uuid)
 		mem_free0(cmld_device_uuid);

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -671,7 +671,7 @@ cmld_reload_container_internal(const uuid_t *uuid, const char *path, container_c
 	container_set_sync_state(c, true);
 
 cleanup:
-	mem_free0(uuid_tmp);
+	uuid_free(uuid_tmp);
 
 	return c;
 }

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1635,8 +1635,14 @@ cmld_init_stage_container(void)
 			  device_config_get_host_dns(device_config));
 
 	cmld_shared_data_dir = mem_printf("%s/%s", cmld_path, CMLD_PATH_SHARED_DATA_DIR);
-	if (mkdir(cmld_shared_data_dir, 0700) < 0 && errno != EEXIST)
-		FATAL_ERRNO("Could not mkdir shared data directory %s", cmld_shared_data_dir);
+	mode_t mode = 0755;
+	if (mkdir(cmld_shared_data_dir, mode) < 0) {
+		if (errno != EEXIST)
+			FATAL_ERRNO("Could not mkdir shared data directory %s",
+				    cmld_shared_data_dir);
+		if (chmod(cmld_shared_data_dir, mode) < 0)
+			FATAL_ERRNO("Could not chmod %s (%o)", cmld_shared_data_dir, mode);
+	}
 
 	const char *update_base_url = device_config_get_update_base_url(device_config);
 	cmld_device_update_base_url = update_base_url ? mem_strdup(update_base_url) : NULL;

--- a/daemon/compartment.c
+++ b/daemon/compartment.c
@@ -454,6 +454,10 @@ compartment_free(compartment_t *compartment)
 	if (compartment->debug_log_dir)
 		mem_free0(compartment->debug_log_dir);
 
+	for (list_t *l = compartment->observer_list; l; l = l->next)
+		mem_free0(l->data);
+	list_delete(compartment->observer_list);
+
 	mem_free0(compartment);
 }
 

--- a/daemon/compartment.c
+++ b/daemon/compartment.c
@@ -428,6 +428,7 @@ compartment_free(compartment_t *compartment)
 
 	uuid_free(compartment->uuid);
 	mem_free0(compartment->name);
+	mem_free0(compartment->description);
 
 	for (list_t *l = compartment->csock_list; l; l = l->next) {
 		compartment_sock_t *cs = l->data;

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -254,10 +254,16 @@ container_free(container_t *container)
 	}
 	list_delete(container->module_allowed_list);
 
-	if (container->device_allowed_list)
+	if (container->device_allowed_list) {
+		for (char **entry = container->device_allowed_list; *entry; entry++)
+			mem_free0(*entry);
 		mem_free0(container->device_allowed_list);
-	if (container->device_assigned_list)
+	}
+	if (container->device_assigned_list) {
+		for (char **entry = container->device_assigned_list; *entry; entry++)
+			mem_free0(*entry);
 		mem_free0(container->device_assigned_list);
+	}
 
 	for (list_t *l = container->usbdev_list; l; l = l->next) {
 		container_usbdev_t *usbdev = l->data;

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -274,6 +274,8 @@ container_free(container_t *container)
 	for (list_t *l = container->vnet_cfg_list; l; l = l->next) {
 		container_vnet_cfg_t *vnet_cfg = l->data;
 		mem_free0(vnet_cfg->vnet_name);
+		if (vnet_cfg->rootns_name)
+			mem_free0(vnet_cfg->rootns_name);
 		mem_free0(vnet_cfg);
 	}
 	list_delete(container->vnet_cfg_list);

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -119,6 +119,16 @@ container_register_compartment_module(compartment_module_t *mod)
 	      list_length(compartment_module_list));
 }
 
+void
+container_unregister_compartment_module(compartment_module_t *mod)
+{
+	ASSERT(mod);
+
+	compartment_module_list = list_remove(compartment_module_list, mod);
+	DEBUG("Container module %s unregistered, nr of hooks: %d)", mod->name,
+	      list_length(compartment_module_list));
+}
+
 container_t *
 container_new(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr, bool ns_net,
 	      const void *os, const char *config_filename, const char *images_dir,

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -347,28 +347,6 @@ void
 container_vnet_cfg_free(container_vnet_cfg_t *vnet_cfg);
 
 /**
- * This function provides the container's runtime config
- * of veth interfaces in form of a container_vnet_cfg_t* list.
- * The elements contain the veth name inside the container and
- * the runtime generated interface name of the rootns endpoint.
- */
-list_t *
-container_get_vnet_runtime_cfg_new(const container_t *container);
-
-/**
- * Registers the corresponding handler for container_get_vnet_runtime_cfg_new
- */
-void
-container_register_get_vnet_runtime_cfg_new_handler(const char *mod_name,
-						    list_t *(*handler)(void *data));
-
-/**
- * Unregisters the corresponding handler for container_get_vnet_runtime_cfg_new
- */
-void
-container_unregister_get_vnet_runtime_cfg_new_handler(void);
-
-/**
  * Initialize a container_pnet_cfg_t data structure and allocate needed memory.
  * @if_name may be either the name or the MAC of the phyiscal NIC
  */
@@ -578,6 +556,13 @@ CONTAINER_MODULE_WRAPPER_DECLARE(add_net_interface, int, container_pnet_cfg_t *p
  * Removes a network interface from the container.
  */
 CONTAINER_MODULE_WRAPPER_DECLARE(remove_net_interface, int, const char *iface)
+
+/**
+ * Provides the container's runtime config of veth interfaces as a
+ * container_vnet_cfg_t * list. Each element contains the veth name inside
+ * the container and the runtime-generated rootns endpoint name.
+ */
+CONTAINER_MODULE_WRAPPER_DECLARE(get_vnet_runtime_cfg_new, list_t *)
 
 /**
  * Registers the corresponding handler for container_setuid0

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -148,6 +148,12 @@ void
 container_register_compartment_module(compartment_module_t *mod);
 
 /**
+ * Unregister a previously registered compartment module.
+ */
+void
+container_unregister_compartment_module(compartment_module_t *mod);
+
+/**
  * constructor that creates a new container instance
  * with the given parameters.
  *
@@ -355,6 +361,12 @@ container_get_vnet_runtime_cfg_new(const container_t *container);
 void
 container_register_get_vnet_runtime_cfg_new_handler(const char *mod_name,
 						    list_t *(*handler)(void *data));
+
+/**
+ * Unregisters the corresponding handler for container_get_vnet_runtime_cfg_new
+ */
+void
+container_unregister_get_vnet_runtime_cfg_new_handler(void);
 
 /**
  * Initialize a container_pnet_cfg_t data structure and allocate needed memory.

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -422,6 +422,14 @@ container_config_get_net_ifaces_list_new(const container_config_t *config)
 		}
 		container_pnet_cfg_t *pnet_cfg = container_pnet_cfg_new(
 			config->cfg->net_ifaces[i]->netif, mac_filter_enabled, mac_whitelist);
+
+		/* container_pnet_cfg_new() deep-copies each entry; release the
+		 * local mac_whitelist (both nodes and entries) regardless of
+		 * whether pnet_cfg creation succeeded. */
+		for (list_t *l = mac_whitelist; l; l = l->next)
+			mem_free0(l->data);
+		list_delete(mac_whitelist);
+
 		if (pnet_cfg == NULL) {
 			ERROR("Failed to create container_pnet_cfg for %s",
 			      config->cfg->net_ifaces[i]->netif);

--- a/daemon/container_module.h
+++ b/daemon/container_module.h
@@ -37,7 +37,8 @@
 // clang-format off
 #define CONTAINER_MODULE_WRAPPER_DECLARE(name, type, ...) \
 	type container_## name(const container_t *container, ##__VA_ARGS__); \
-	void container_register_## name ##_handler(const char *mod_name, type (*h)(void *, ##__VA_ARGS__));
+	void container_register_## name ##_handler(const char *mod_name, type (*h)(void *, ##__VA_ARGS__)); \
+	void container_unregister_## name ##_handler(void);
 
 #define CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(name, type, ...) \
 	typedef struct { \
@@ -55,6 +56,14 @@
 		container_## name ##_handler->mod_name = mod_name; \
 		container_## name ##_handler->handler_func = h; \
 		INFO("%s_handler registerd by module '%s'.", #name, mod_name); \
+	} \
+	void container_unregister_## name ##_handler(void) \
+	{ \
+		if (container_## name ##_handler) { \
+			INFO("%s_handler unregisterd by module '%s'.", #name, \
+			     container_## name ##_handler->mod_name); \
+			mem_free0(container_## name ##_handler); \
+		} \
 	}
 
 #define CONTAINER_MODULE_FUNCTION_WRAPPER_IMPL(name, type, unimpl) \

--- a/daemon/container_module.h
+++ b/daemon/container_module.h
@@ -25,7 +25,7 @@
  * @file container_module.h
  *
  * Module macro magic to avoid code duplication and
- * functions implementd by submodules using those macros
+ * functions implemented by submodules using those macros
  */
 
 #ifndef CONTAINER_MODULE_H
@@ -49,18 +49,18 @@
 	void container_register_## name ##_handler(const char *mod_name, type (*h)(__VA_ARGS__)) \
 	{ \
 		if (container_## name ##_handler) { \
-			WARN("%s_handler allready registered, skip", #name); \
+			WARN("%s_handler already registered, skip", #name); \
 			return; \
 		} \
 		container_## name ##_handler = mem_new0(container_## name ##_handler_t, 1); \
 		container_## name ##_handler->mod_name = mod_name; \
 		container_## name ##_handler->handler_func = h; \
-		INFO("%s_handler registerd by module '%s'.", #name, mod_name); \
+		INFO("%s_handler registered by module '%s'.", #name, mod_name); \
 	} \
 	void container_unregister_## name ##_handler(void) \
 	{ \
 		if (container_## name ##_handler) { \
-			INFO("%s_handler unregisterd by module '%s'.", #name, \
+			INFO("%s_handler unregistered by module '%s'.", #name, \
 			     container_## name ##_handler->mod_name); \
 			mem_free0(container_## name ##_handler); \
 		} \

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -69,6 +69,7 @@
 struct control {
 	int sock; // listen socket fd
 	bool privileged;
+	event_io_t *event_io_accept;	      // event_io for the listening socket
 	list_t *event_io_sock_connected_list; // list of clients
 };
 
@@ -1964,8 +1965,8 @@ control_new(int sock, bool privileged)
 	control->sock = sock;
 	control->privileged = privileged;
 
-	event_io_t *event = event_io_new(sock, EVENT_IO_READ, control_cb_accept, control);
-	event_add_io(event);
+	control->event_io_accept = event_io_new(sock, EVENT_IO_READ, control_cb_accept, control);
+	event_add_io(control->event_io_accept);
 
 	return control;
 }
@@ -1999,6 +2000,12 @@ control_free(control_t *control)
 	}
 	list_delete(control->event_io_sock_connected_list);
 	control->event_io_sock_connected_list = NULL;
+
+	if (control->event_io_accept) {
+		event_remove_io(control->event_io_accept);
+		event_io_free(control->event_io_accept);
+		control->event_io_accept = NULL;
+	}
 
 	control_list = list_remove(control_list, control);
 

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -481,14 +481,20 @@ push_config_verify_buf_cb(crypto_verify_result_t verify_result, unsigned char *c
 	ASSERT(resp_fd);
 
 	guestos_t *os = guestos_new_from_buffer(cfg_buf, cfg_buf_len, guestos_basepath);
-	const char *os_name = NULL;
+
+	/*
+	 * guestos_get_name() borrows a pointer into the protobuf-unpacked
+	 * config owned by os. Duplicate it so it survives guestos_free() and
+	 * remains valid for the audit_log_event() at the err label.
+	 */
+	char *os_name = mem_strdup(os ? guestos_get_name(os) : "NA");
+
 	if (!os) {
 		audit_log_event(NULL, FSA, CMLD, GUESTOS_MGMT, "push-os-invalid", guestos_basepath,
 				0);
 		ERROR("Could not instantiate GuestOS from buffer");
 		goto err;
 	}
-	os_name = guestos_get_name(os);
 
 	switch (verify_result) {
 	case VERIFY_GOOD:
@@ -603,6 +609,7 @@ trigger_download:
 	guestos_mgr_download_latest(os_name, *resp_fd);
 
 	mem_free0(resp_fd);
+	mem_free0(os_name);
 	return;
 
 cleanup_purge:
@@ -617,6 +624,7 @@ err:
 	if (control_send_message(CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_FAILED, *resp_fd) < 0)
 		WARN("Could not send response to fd=%d", *resp_fd);
 	mem_free0(resp_fd);
+	mem_free0(os_name);
 }
 
 int

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -568,6 +568,11 @@ push_config_verify_buf_cb(crypto_verify_result_t verify_result, unsigned char *c
 		} else if (os_ver == old_ver) {
 			DEBUG("Retrigger download of GuestOS images for %s of v%" PRIu64 ".",
 			      os_name, os_ver);
+			/*
+			 * os with this version is already registered; free the duplicate
+			 * from the repeated push
+			 */
+			guestos_free(os);
 			goto trigger_download;
 		}
 		DEBUG("Updating GuestOS config for %s from v%" PRIu64 " to v%" PRIu64 ".", os_name,

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -451,13 +451,26 @@ guestos_mgr_update_images(void)
 static char *
 write_to_tmpfile_new(unsigned char *buf, size_t buflen)
 {
-	/* this fixes the problem that /tmp is unshared between cmld and scd which is why
+	/*
+	 * this fixes the problem that /tmp is unshared between cmld and scd which is why
 	 * it cannot be used to share files to be hashed (e.g. newca_certs)
-	 * FIXME: move SCD in own container and introduce shared mount
 	 */
 	char *file = mem_printf("%s/shared/tmpXXXXXXXX", DEFAULT_BASE_PATH);
+	mode_t mode = 00644;
 	int fd = mkstemp(file);
 	if (fd != -1) {
+		/*
+		 * mkstemp generates files with 600, thus ensure units especially the SCD
+		 * can read this.
+		 */
+		if (fchmod(fd, mode)) {
+			ERROR_ERRNO("Could not chmod temp file %s (%o)", file, mode);
+			close(fd);
+			if (unlink(file))
+				WARN_ERRNO("Failed to delete tmpfile %s", file);
+			mem_free0(file);
+			return NULL;
+		}
 		int len = fd_write(fd, (char *)buf, buflen);
 		close(fd);
 		if (len >= 0 && (size_t)len == buflen)

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -626,6 +626,7 @@ trigger_download:
 		WARN("Could not send response to fd=%d", *resp_fd);
 	guestos_mgr_download_latest(os_name, *resp_fd);
 
+	mount_free(mnt);
 	mem_free0(resp_fd);
 	mem_free0(os_name);
 	return;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -98,9 +98,17 @@ main_logfile_rename_cb(UNUSED event_timer_t *timer, UNUSED void *data)
 	logf_handler_set_prio(cml_daemon_logfile_handler, LOGF_PRIO_TRACE);
 }
 
-static void
-main_logf_cleanup()
+/*
+ * Tagged DEINIT_LAST so it fires after every other DEINIT in the daemon.
+ * Drains the event subsystem (any signal/timer/inotify entries that
+ * subsystems failed to remove themselves) and then closes the log
+ * handlers last so per-module deinit messages still reach the log file.
+ */
+DEINIT_LAST static void
+main_deinit(void)
 {
+	event_reset();
+
 	logf_unregister(cml_daemon_logfile_handler);
 	logf_unregister(cml_daemon_stdout_handler);
 
@@ -119,15 +127,6 @@ main_init(void)
 	main_logfile_p = logf_file_new(LOGFILE_DIR "/cml-daemon");
 	cml_daemon_logfile_handler = logf_register(&logf_file_write, main_logfile_p);
 	logf_handler_set_prio(cml_daemon_logfile_handler, LOGF_PRIO_TRACE);
-
-	/*
-	 * Register logf cleanup as an INIT-time atexit so it runs after every
-	 * atexit added later from main() / cmld_init (LIFO order). Other
-	 * shutdown paths may still want to log; main_logf_cleanup must fire
-	 * last.
-	 */
-	if (atexit(&main_logf_cleanup))
-		WARN("could not register on exit cleanup method 'main_logf_cleanup()'");
 
 	main_core_dump_enable();
 }

--- a/daemon/mount.c
+++ b/daemon/mount.c
@@ -104,6 +104,8 @@ mount_free(mount_t *mnt)
 			mem_free0(mntent->sha1);
 		if (mntent->sha256)
 			mem_free0(mntent->sha256);
+		if (mntent->verity_sha256)
+			mem_free0(mntent->verity_sha256);
 		if (mntent->mount_data)
 			mem_free0(mntent->mount_data);
 		mem_free0(mntent);

--- a/daemon/scd.c
+++ b/daemon/scd.c
@@ -286,8 +286,11 @@ scd_cleanup(void)
 {
 	unit_kill(scd_unit);
 	if (scd_event_io) {
+		int fd = event_io_get_fd(scd_event_io);
 		event_remove_io(scd_event_io);
 		event_io_free(scd_event_io);
+		if (close(fd) < 0)
+			WARN_ERRNO("Failed to close connected scd event socket");
 		scd_event_io = NULL;
 	}
 	if (scd_sock_path)

--- a/daemon/scd.c
+++ b/daemon/scd.c
@@ -167,6 +167,19 @@ scd_on_connect_cb(int sock, const char *sock_path)
 	/* register socket for receiving data */
 	fd_make_non_blocking(sock);
 
+	/*
+	 * release a stale event io of a previous connection whose error
+	 * event has not been handled yet, otherwise it would be leaked by
+	 * the overwrite below
+	 */
+	if (scd_event_io) {
+		int old_fd = event_io_get_fd(scd_event_io);
+		event_remove_io(scd_event_io);
+		event_io_free(scd_event_io);
+		if (close(old_fd) < 0)
+			WARN_ERRNO("Failed to close stale scd event socket");
+	}
+
 	scd_event_io = event_io_new(sock, EVENT_IO_READ, &scd_event_cb_recv_message, NULL);
 	event_add_io(scd_event_io);
 

--- a/daemon/scd.c
+++ b/daemon/scd.c
@@ -216,9 +216,10 @@ scd_init(void)
 	mem_free(legacy_device_id_path);
 
 	// if device.cert is not present, scd will die. Hence, we set autorestart in unit_new
-	scd_unit = unit_new(uuid_new(SCD_UUID), "SCD", SCD_BINARY_NAME, NULL, NULL, 0, true,
-			    SCD_TOKEN_DIR, SCD_CONTROL_SOCKET, SOCK_SEQPACKET, &scd_on_connect_cb,
-			    true);
+	uuid_t *scd_uuid = uuid_new(SCD_UUID);
+	scd_unit = unit_new(scd_uuid, "SCD", SCD_BINARY_NAME, NULL, NULL, 0, true, SCD_TOKEN_DIR,
+			    SCD_CONTROL_SOCKET, SOCK_SEQPACKET, &scd_on_connect_cb, true);
+	uuid_free(scd_uuid);
 
 	IF_NULL_RETVAL(scd_unit, -1);
 

--- a/daemon/scd.c
+++ b/daemon/scd.c
@@ -59,6 +59,7 @@
 char *scd_sock_path = NULL;
 
 static unit_t *scd_unit;
+static event_io_t *scd_event_io = NULL;
 
 static int
 scd_register_listener(int fd)
@@ -140,6 +141,8 @@ scd_event_cb_recv_message(int fd, unsigned events, event_io_t *io, UNUSED void *
 connection_err:
 	event_remove_io(io);
 	event_io_free(io);
+	if (io == scd_event_io)
+		scd_event_io = NULL;
 	if (close(fd) < 0)
 		WARN_ERRNO("Failed to close connected scd event socket");
 	return;
@@ -164,8 +167,8 @@ scd_on_connect_cb(int sock, const char *sock_path)
 	/* register socket for receiving data */
 	fd_make_non_blocking(sock);
 
-	event_io_t *event = event_io_new(sock, EVENT_IO_READ, &scd_event_cb_recv_message, NULL);
-	event_add_io(event);
+	scd_event_io = event_io_new(sock, EVENT_IO_READ, &scd_event_cb_recv_message, NULL);
+	event_add_io(scd_event_io);
 
 	/* notify containers about (re-)connection of the scd */
 	for (int i = 0; i < cmld_containers_get_count(); i++) {
@@ -269,6 +272,11 @@ void
 scd_cleanup(void)
 {
 	unit_kill(scd_unit);
+	if (scd_event_io) {
+		event_remove_io(scd_event_io);
+		event_io_free(scd_event_io);
+		scd_event_io = NULL;
+	}
 	if (scd_sock_path)
 		mem_free0(scd_sock_path);
 	unit_free(scd_unit);

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -147,9 +147,11 @@ tss_init(void)
 	}
 
 	// Start the tpm2d
-	tpm2d_unit = unit_new(uuid_new(TPM2D_UUID), "TPM2D", TPM2D_BINARY_NAME, NULL, NULL, 0,
-			      false, TPM2D_BASE_DIR, TPM2D_CONTROL_SOCKET, SOCK_STREAM,
+	uuid_t *tpm2d_uuid = uuid_new(TPM2D_UUID);
+	tpm2d_unit = unit_new(tpm2d_uuid, "TPM2D", TPM2D_BINARY_NAME, NULL, NULL, 0, false,
+			      TPM2D_BASE_DIR, TPM2D_CONTROL_SOCKET, SOCK_STREAM,
 			      &tss_tpm2d_on_connect_cb, true);
+	uuid_free(tpm2d_uuid);
 
 	// grant access to the TPM
 	list_t *dev_nodes = list_append(NULL, "/dev/tpmrm0");

--- a/daemon/u_idmapped.c
+++ b/daemon/u_idmapped.c
@@ -123,6 +123,10 @@ u_idmapped_free(void *idmappedp)
 	u_idmapped_t *idmapped = idmappedp;
 	ASSERT(idmapped);
 
+	for (list_t *l = idmapped->mnt_list; l; l = l->next)
+		u_idmapped_mnt_free(l->data);
+	list_delete(idmapped->mnt_list);
+
 	mem_free0(idmapped);
 }
 

--- a/daemon/u_idmapped.c
+++ b/daemon/u_idmapped.c
@@ -251,3 +251,9 @@ u_idmapped_init(void)
 	// register this module in unit.c
 	unit_register_compartment_module(&u_idmapped_module);
 }
+
+static void DEINIT
+u_idmapped_deinit(void)
+{
+	unit_unregister_compartment_module(&u_idmapped_module);
+}

--- a/daemon/u_net.c
+++ b/daemon/u_net.c
@@ -116,3 +116,9 @@ u_net_init(void)
 	// register this module in unit.c
 	unit_register_compartment_module(&u_net_module);
 }
+
+static void DEINIT
+u_net_deinit(void)
+{
+	unit_unregister_compartment_module(&u_net_module);
+}

--- a/daemon/u_perm.c
+++ b/daemon/u_perm.c
@@ -309,3 +309,9 @@ u_perm_init(void)
 	// register this module in unit.c
 	unit_register_compartment_module(&u_perm_module);
 }
+
+static void DEINIT
+u_perm_deinit(void)
+{
+	unit_unregister_compartment_module(&u_perm_module);
+}

--- a/daemon/u_service.c
+++ b/daemon/u_service.c
@@ -222,3 +222,9 @@ u_service_init(void)
 	// register this module in unit.c
 	unit_register_compartment_module(&u_service_module);
 }
+
+static void DEINIT
+u_service_deinit(void)
+{
+	unit_unregister_compartment_module(&u_service_module);
+}

--- a/daemon/u_time.c
+++ b/daemon/u_time.c
@@ -126,3 +126,9 @@ u_time_init(void)
 	// register this module in unit.c
 	unit_register_compartment_module(&u_time_module);
 }
+
+static void DEINIT
+u_time_deinit(void)
+{
+	unit_unregister_compartment_module(&u_time_module);
+}

--- a/daemon/u_usb.c
+++ b/daemon/u_usb.c
@@ -224,3 +224,9 @@ u_usb_init(void)
 	// register this module in unit.c
 	unit_register_compartment_module(&u_usb_module);
 }
+
+static void DEINIT
+u_usb_deinit(void)
+{
+	unit_unregister_compartment_module(&u_usb_module);
+}

--- a/daemon/u_user.c
+++ b/daemon/u_user.c
@@ -373,3 +373,9 @@ u_user_init(void)
 	if (chmod(LOGFILE_DIR, mode))
 		WARN_ERRNO("Could not chmod %s (%o)", LOGFILE_DIR, mode);
 }
+
+static void DEINIT
+u_user_deinit(void)
+{
+	unit_unregister_compartment_module(&u_user_module);
+}

--- a/daemon/unit.c
+++ b/daemon/unit.c
@@ -87,6 +87,16 @@ unit_register_compartment_module(compartment_module_t *mod)
 	      list_length(compartment_module_list));
 }
 
+void
+unit_unregister_compartment_module(compartment_module_t *mod)
+{
+	ASSERT(mod);
+
+	compartment_module_list = list_remove(compartment_module_list, mod);
+	DEBUG("Unit module %s unregistered, nr of hooks: %d)", mod->name,
+	      list_length(compartment_module_list));
+}
+
 unit_t *
 unit_new(const uuid_t *uuid, const char *name, const char *command, char **argv, const char **env,
 	 size_t env_len, bool netns, const char *data_path, const char *sock_name, int sock_type,

--- a/daemon/unit.h
+++ b/daemon/unit.h
@@ -34,6 +34,9 @@ typedef struct unit unit_t;
 void
 unit_register_compartment_module(compartment_module_t *mod);
 
+void
+unit_unregister_compartment_module(compartment_module_t *mod);
+
 unit_t *
 unit_new(const uuid_t *uuid, const char *name, const char *command, char **argv, const char **env,
 	 size_t env_len, bool netns, const char *data_path, const char *sock_name, int sock_type,


### PR DESCRIPTION
  This series fixes a collection of memory leaks in cmld (mostly found with ASan), introduces infrastructure for clean
  module teardown at exit, and contains two small functional fixes needed since SCD runs as a unit with its own user
  namespace.

##  Teardown infrastructure

  - New DEINIT / DEINIT_LAST macros in common/macro.h as the symmetric counterpart to INIT
  (__attribute__((destructor)), with DEINIT_LAST pinned to the lowest priority so it fires after all other
  destructors).
  - container.c and unit.c gain paired unregister APIs for their static compartment-module lists, and
  CONTAINER_MODULE_REGISTER_WRAPPER_IMPL now emits a matching container_unregister_*_handler(). Every c_* / u_* module
  gets a DEINIT-marked deinit that unregisters what it registered, so registration and cleanup live next to each
  other and no central sweep is needed.
  - main()'s signal/timer handlers are drained via event_reset() in main_deinit() (DEINIT_LAST), preserving the "logf
  teardown happens last" guarantee.

##  Runtime memory-leak fixes (accumulate during normal operation)

  - mount_free() releases verity_sha256 (leaked per dm-verity image on every mount-table teardown).
  - container_free() releases vnet_cfg->rootns_name and the entries of device_allowed_list / device_assigned_list.
  - container_config_get_net_ifaces_list_new() releases its local mac_whitelist after container_pnet_cfg_new()
  deep-copies it.
  - u_idmapped_free() walks and frees mnt_list; c_cgroups_dev frees its per-container cgroup path; c_vol_cleanup_dm()
  frees the dm label on the early-continue path.
  - compartment_free() releases description and drains residual observer_list entries.
  - push_config_verify_buf_cb() frees the duplicate guestos_t on same-version re-pushes and the disk-space-check
  mount_t on all success paths.

## Exit-time releases

  - audit, scd and control release their netlink socket / event_io_t handles at shutdown; scd_on_connect_cb()
  additionally releases a stale event io left over from a previous connection before overwriting the handle, and
  scd_cleanup() closes the underlying socket fd to mirror the runtime disconnect path.
  - uuid_free() is used for the inline uuid_new() results in scd_init() / tss_init() and for uuid_tmp in
  cmld_reload_container_internal() (previous mem_free0() leaked the inner string).
  - cmld_cleanup() releases cmld_wrapped_keys_path.

##  Bug fix

  - Use-after-free: push_config_verify_buf_cb() borrowed os_name from the protobuf-unpacked config, which
  guestos_free() released before the audit log on error paths read it (flagged by ASan). The name is now duplicated
  into a heap-owned local.

##  Functional fixes for SCD as unit

  - The shared data directory under DEFAULT_BASE_PATH/shared is created (and enforced on restart) as 0755, and
  write_to_tmpfile_new() chmods its output to 0644, so the SCD unit can read files handed over by cmld across the uid  mapping. Only public CA certificates are placed there; owner-only write is preserved.

##  Misc

  - file_disk_space_available() logs the actual required/available/threshold values on failure.
  - Typo fixes in container_module.h logs/comments; get_vnet_runtime_cfg_new handler declarations converted to
  CONTAINER_MODULE_WRAPPER_DECLARE() like every other handler.
