### PR TITLE
common/ns: Set ns_join_by_pid log message to TRACE

### DIFF
--- a/common/ns.c
+++ b/common/ns.c
@@ -470,6 +470,6 @@ ns_join_by_pid(pid_t pid, int nstype)
 	}
 
 	close(fd);
-	INFO("Sucessfully joined ns of pid by pid: %d.", pid);
+	TRACE("Sucessfully joined ns of pid by pid: %d.", pid);
 	return 0;
 }


### PR DESCRIPTION
Since the implementation of the sysinfo emulation dd512a2, 
the ns_join_by_pid function frequently logs INFO messages. 
The source of these are the namespace joins by the sysinfo emulation 
to read the limits of the container.

To avoid large log files, this message will be set on TRACE.