### PR TITLE
daemon/c_net: Check if veth name is NULL before removing

### DIFF
--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1618,6 +1618,9 @@ c_net_cleanup(void *netp, bool is_rebooting)
 		for (list_t *l = net->interface_list; l; l = l->next) {
 			c_net_interface_t *ni = l->data;
 			// delete veth pair if it was created!
+			if (ni->veth_cmld_name == NULL) {
+				continue;
+			}
 			if (ni->created && c_net_is_veth_used(ni->veth_cmld_name)) {
 				DEBUG("Removing veth interface %s", ni->veth_cmld_name);
 				c_net_interface_down(ni->veth_cmld_name);


### PR DESCRIPTION
If the veth implementation is facing an err before c_net_cleanup, the veth is left with a NULL value as name.
Executing function c_net_interface_down with an empty veth name value is causing a FATAL error.

The c_net_cleanup function iterates through
all network interfaces in the interface_list.
If the veth_cmld_name is NULL, the solution is to
continue the iteration.