### PR TITLE
daemon/container: Verify module ownership when unregistering handlers

### DIFF
--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -229,12 +229,14 @@ c_audit_init(void)
 static void DEINIT
 c_audit_deinit(void)
 {
-	container_unregister_audit_get_last_ack_handler();
-	container_unregister_audit_set_last_ack_handler();
-	container_unregister_audit_get_processing_ack_handler();
-	container_unregister_audit_set_processing_ack_handler();
-	container_unregister_audit_get_loginuid_handler();
-	container_unregister_audit_set_loginuid_handler();
+	// unregister handlers implemented by this module
+	container_unregister_audit_get_last_ack_handler(MOD_NAME, c_audit_get_last_ack);
+	container_unregister_audit_set_last_ack_handler(MOD_NAME, c_audit_set_last_ack);
+	container_unregister_audit_get_processing_ack_handler(MOD_NAME, c_audit_get_processing_ack);
+	container_unregister_audit_set_processing_ack_handler(MOD_NAME, c_audit_set_processing_ack);
+	container_unregister_audit_get_loginuid_handler(MOD_NAME, c_audit_get_loginuid);
+	container_unregister_audit_set_loginuid_handler(MOD_NAME, c_audit_set_loginuid);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_audit_module);
 }

--- a/daemon/c_automount.c
+++ b/daemon/c_automount.c
@@ -285,5 +285,6 @@ c_automount_init(void)
 static void DEINIT
 c_automount_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_automount_module);
 }

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -170,7 +170,9 @@ c_cap_init(void)
 static void DEINIT
 c_cap_deinit(void)
 {
-	container_unregister_set_cap_current_process_handler();
+	// unregister handlers implemented by this module
+	container_unregister_set_cap_current_process_handler(MOD_NAME, c_cap_set_current_process);
 
+	// unregister this module in container.c
 	container_unregister_compartment_module(&c_cap_module);
 }

--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -1321,16 +1321,37 @@ static compartment_module_t c_cgroups_module = {
 	.join_ns = NULL,
 };
 
+static void INIT
+c_cgroups_init(void)
+{
+	// register this module in container.c
+	container_register_compartment_module(&c_cgroups_module);
+
+	// register relevant handlers implemented by this module
+	container_register_freeze_handler(MOD_NAME, c_cgroups_freeze);
+	container_register_unfreeze_handler(MOD_NAME, c_cgroups_unfreeze);
+	container_register_device_allow_handler(MOD_NAME, c_cgroups_devices_dev_allow);
+	container_register_device_deny_handler(MOD_NAME, c_cgroups_devices_dev_deny);
+	container_register_is_device_allowed_handler(MOD_NAME, c_cgroups_devices_is_dev_allowed);
+	container_register_add_pid_to_cgroups_handler(MOD_NAME, c_cgroups_add_pid);
+
+	// mount cgroups if not allready mounted by init
+	if (mount_cgroups(get_active_cgroups_subsystems()))
+		FATAL("Could not mount cgroups");
+}
+
 static void DEINIT
 c_cgroups_deinit(void)
 {
-	container_unregister_freeze_handler();
-	container_unregister_unfreeze_handler();
-	container_unregister_device_allow_handler();
-	container_unregister_device_deny_handler();
-	container_unregister_is_device_allowed_handler();
-	container_unregister_add_pid_to_cgroups_handler();
+	// unregister handlers implemented by this module
+	container_unregister_freeze_handler(MOD_NAME, c_cgroups_freeze);
+	container_unregister_unfreeze_handler(MOD_NAME, c_cgroups_unfreeze);
+	container_unregister_device_allow_handler(MOD_NAME, c_cgroups_devices_dev_allow);
+	container_unregister_device_deny_handler(MOD_NAME, c_cgroups_devices_dev_deny);
+	container_unregister_is_device_allowed_handler(MOD_NAME, c_cgroups_devices_is_dev_allowed);
+	container_unregister_add_pid_to_cgroups_handler(MOD_NAME, c_cgroups_add_pid);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_cgroups_module);
 
 	/*
@@ -1350,23 +1371,4 @@ c_cgroups_deinit(void)
 	}
 	list_delete(global_allowed_devs_list);
 	global_allowed_devs_list = NULL;
-}
-
-static void INIT
-c_cgroups_init(void)
-{
-	// register this module in container.c
-	container_register_compartment_module(&c_cgroups_module);
-
-	// register relevant handlers implemented by this module
-	container_register_freeze_handler(MOD_NAME, c_cgroups_freeze);
-	container_register_unfreeze_handler(MOD_NAME, c_cgroups_unfreeze);
-	container_register_device_allow_handler(MOD_NAME, c_cgroups_devices_dev_allow);
-	container_register_device_deny_handler(MOD_NAME, c_cgroups_devices_dev_deny);
-	container_register_is_device_allowed_handler(MOD_NAME, c_cgroups_devices_is_dev_allowed);
-	container_register_add_pid_to_cgroups_handler(MOD_NAME, c_cgroups_add_pid);
-
-	// mount cgroups if not allready mounted by init
-	if (mount_cgroups(get_active_cgroups_subsystems()))
-		FATAL("Could not mount cgroups");
 }

--- a/daemon/c_cgroups_dev.c
+++ b/daemon/c_cgroups_dev.c
@@ -1059,14 +1059,29 @@ static compartment_module_t c_cgroups_dev_module = {
 	.join_ns = NULL,
 };
 
+static void INIT
+c_cgroups_dev_init(void)
+{
+	// register this module in container.c
+	container_register_compartment_module(&c_cgroups_dev_module);
+
+	// register relevant handlers implemented by this module
+	container_register_device_allow_handler(MOD_NAME, c_cgroups_dev_device_allow);
+	container_register_device_deny_handler(MOD_NAME, c_cgroups_dev_device_deny);
+	container_register_device_set_access_handler(MOD_NAME, c_cgroups_dev_device_set_access);
+	container_register_is_device_allowed_handler(MOD_NAME, c_cgroups_dev_is_dev_allowed);
+}
+
 static void DEINIT
 c_cgroups_dev_deinit(void)
 {
-	container_unregister_device_allow_handler();
-	container_unregister_device_deny_handler();
-	container_unregister_device_set_access_handler();
-	container_unregister_is_device_allowed_handler();
+	// unregister handlers implemented by this module
+	container_unregister_device_allow_handler(MOD_NAME, c_cgroups_dev_device_allow);
+	container_unregister_device_deny_handler(MOD_NAME, c_cgroups_dev_device_deny);
+	container_unregister_device_set_access_handler(MOD_NAME, c_cgroups_dev_device_set_access);
+	container_unregister_is_device_allowed_handler(MOD_NAME, c_cgroups_dev_is_dev_allowed);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_cgroups_dev_module);
 
 	/*
@@ -1087,17 +1102,4 @@ c_cgroups_dev_deinit(void)
 	}
 	list_delete(global_allowed_devs_list);
 	global_allowed_devs_list = NULL;
-}
-
-static void INIT
-c_cgroups_dev_init(void)
-{
-	// register this module in container.c
-	container_register_compartment_module(&c_cgroups_dev_module);
-
-	// register relevant handlers implemented by this module
-	container_register_device_allow_handler(MOD_NAME, c_cgroups_dev_device_allow);
-	container_register_device_deny_handler(MOD_NAME, c_cgroups_dev_device_deny);
-	container_register_device_set_access_handler(MOD_NAME, c_cgroups_dev_device_set_access);
-	container_register_is_device_allowed_handler(MOD_NAME, c_cgroups_dev_is_dev_allowed);
 }

--- a/daemon/c_cgroups_sockopt.c
+++ b/daemon/c_cgroups_sockopt.c
@@ -336,5 +336,6 @@ c_cgroups_sockopt_init(void)
 static void DEINIT
 c_cgroups_sockopt_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_cgroups_sockopt_module);
 }

--- a/daemon/c_cgroups_v2.c
+++ b/daemon/c_cgroups_v2.c
@@ -667,20 +667,6 @@ static compartment_module_t c_cgroups_module = {
 	.join_ns = NULL,
 };
 
-DEINIT static void
-c_cgroups_deinit(void)
-{
-	container_unregister_add_pid_to_cgroups_handler();
-	container_unregister_freeze_handler();
-	container_unregister_unfreeze_handler();
-
-	container_unregister_compartment_module(&c_cgroups_module);
-
-	// free global memory alloctaions
-	if (c_cgroups_subtree)
-		mem_free0(c_cgroups_subtree);
-}
-
 static void INIT
 c_cgroups_init(void)
 {
@@ -721,4 +707,20 @@ c_cgroups_init(void)
 		FATAL("Could not activate cgroup controllers for cmld!");
 
 	mem_free0(cgroup_cmld);
+}
+
+DEINIT static void
+c_cgroups_deinit(void)
+{
+	// unregister handlers implemented by this module
+	container_unregister_add_pid_to_cgroups_handler(MOD_NAME, c_cgroups_add_pid);
+	container_unregister_freeze_handler(MOD_NAME, c_cgroups_freeze);
+	container_unregister_unfreeze_handler(MOD_NAME, c_cgroups_unfreeze);
+
+	// unregister this module from container.c
+	container_unregister_compartment_module(&c_cgroups_module);
+
+	// free global memory alloctaions
+	if (c_cgroups_subtree)
+		mem_free0(c_cgroups_subtree);
 }

--- a/daemon/c_fifo.c
+++ b/daemon/c_fifo.c
@@ -488,9 +488,17 @@ static compartment_module_t c_fifo_module = {
 	.join_ns = NULL,
 };
 
+static void INIT
+c_fifo_init(void)
+{
+	// register this module in container.c
+	container_register_compartment_module(&c_fifo_module);
+}
+
 static void DEINIT
 c_fifo_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_fifo_module);
 
 	/*
@@ -499,11 +507,4 @@ c_fifo_deinit(void)
 	 */
 	list_delete(c0_fifo_list);
 	c0_fifo_list = NULL;
-}
-
-static void INIT
-c_fifo_init(void)
-{
-	// register this module in container.c
-	container_register_compartment_module(&c_fifo_module);
 }

--- a/daemon/c_hotplug.c
+++ b/daemon/c_hotplug.c
@@ -740,9 +740,17 @@ static compartment_module_t c_hotplug_module = {
 	.join_ns = NULL,
 };
 
+static void INIT
+c_hotplug_init(void)
+{
+	// register this module in container.c
+	container_register_compartment_module(&c_hotplug_module);
+}
+
 static void DEINIT
 c_hotplug_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_hotplug_module);
 
 	/*
@@ -751,11 +759,4 @@ c_hotplug_deinit(void)
 	 */
 	list_delete(c_hotplug_token_list);
 	c_hotplug_token_list = NULL;
-}
-
-static void INIT
-c_hotplug_init(void)
-{
-	// register this module in container.c
-	container_register_compartment_module(&c_hotplug_module);
 }

--- a/daemon/c_idmapped.c
+++ b/daemon/c_idmapped.c
@@ -668,7 +668,9 @@ c_idmapped_init(void)
 static void DEINIT
 c_idmapped_deinit(void)
 {
-	container_unregister_shift_ids_handler();
+	// unregister handlers implemented by this module
+	container_unregister_shift_ids_handler(MOD_NAME, c_idmapped_shift_ids);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_idmapped_module);
 }

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1782,9 +1782,12 @@ c_net_init(void)
 static void DEINIT
 c_net_deinit(void)
 {
-	container_unregister_add_net_interface_handler();
-	container_unregister_remove_net_interface_handler();
-	container_unregister_get_vnet_runtime_cfg_new_handler();
+	// unregister handlers implemented by this module
+	container_unregister_add_net_interface_handler(MOD_NAME, c_net_add_interface);
+	container_unregister_remove_net_interface_handler(MOD_NAME, c_net_remove_interface);
+	container_unregister_get_vnet_runtime_cfg_new_handler(MOD_NAME,
+							      c_net_get_interface_mapping_new);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_net_module);
 }

--- a/daemon/c_oci.c
+++ b/daemon/c_oci.c
@@ -199,5 +199,6 @@ c_oci_init(void)
 static void DEINIT
 c_oci_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_oci_module);
 }

--- a/daemon/c_run.c
+++ b/daemon/c_run.c
@@ -721,9 +721,11 @@ c_run_init(void)
 static void DEINIT
 c_run_deinit(void)
 {
-	container_unregister_run_handler();
-	container_unregister_write_exec_input_handler();
-	container_unregister_get_console_sock_cmld_handler();
+	// unregister handlers implemented by this module
+	container_unregister_run_handler(MOD_NAME, c_run_exec_process);
+	container_unregister_write_exec_input_handler(MOD_NAME, c_run_write_exec_input);
+	container_unregister_get_console_sock_cmld_handler(MOD_NAME, c_run_get_console_sock_cmld);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_run_module);
 }

--- a/daemon/c_seccomp/seccomp.c
+++ b/daemon/c_seccomp/seccomp.c
@@ -645,5 +645,6 @@ c_seccomp_init(void)
 static void DEINIT
 c_seccomp_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_seccomp_module);
 }

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -526,9 +526,12 @@ c_service_init(void)
 static void DEINIT
 c_service_deinit(void)
 {
-	container_unregister_audit_record_send_handler();
-	container_unregister_audit_record_notify_handler();
-	container_unregister_audit_notify_complete_handler();
+	// unregister handlers implemented by this module
+	container_unregister_audit_record_send_handler(MOD_NAME, c_service_audit_send_record);
+	container_unregister_audit_record_notify_handler(MOD_NAME, c_service_audit_notify);
+	container_unregister_audit_notify_complete_handler(MOD_NAME,
+							   c_service_audit_notify_complete);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_service_module);
 }

--- a/daemon/c_smartcard.c
+++ b/daemon/c_smartcard.c
@@ -1356,14 +1356,16 @@ c_smartcard_init(void)
 static void DEINIT
 c_smartcard_deinit(void)
 {
-	container_unregister_ctrl_with_smartcard_handler();
-	container_unregister_set_smartcard_error_cb_handler();
-	container_unregister_change_pin_handler();
-	container_unregister_scd_release_pairing_handler();
-	container_unregister_token_attach_handler();
-	container_unregister_token_detach_handler();
-	container_unregister_has_token_changed_handler();
-	container_unregister_scd_connect_handler();
+	// unregister handlers implemented by this module
+	container_unregister_ctrl_with_smartcard_handler(MOD_NAME, c_smartcard_container_ctrl);
+	container_unregister_set_smartcard_error_cb_handler(MOD_NAME, c_smartcard_set_error_cb);
+	container_unregister_change_pin_handler(MOD_NAME, c_smartcard_change_pin);
+	container_unregister_scd_release_pairing_handler(MOD_NAME, c_smartcard_scd_release_pairing);
+	container_unregister_token_attach_handler(MOD_NAME, c_smartcard_token_attach);
+	container_unregister_token_detach_handler(MOD_NAME, c_smartcard_token_detach);
+	container_unregister_has_token_changed_handler(MOD_NAME, c_smartcard_has_token_changed);
+	container_unregister_scd_connect_handler(MOD_NAME, c_smartcard_scd_connect);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_smartcard_module);
 }

--- a/daemon/c_time.c
+++ b/daemon/c_time.c
@@ -296,8 +296,10 @@ c_time_init(void)
 static void DEINIT
 c_time_deinit(void)
 {
-	container_unregister_get_creation_time_handler();
-	container_unregister_get_uptime_handler();
+	// unregister relevant handlers implemented by this module
+	container_unregister_get_creation_time_handler(MOD_NAME, c_time_get_creation_time);
+	container_unregister_get_uptime_handler(MOD_NAME, c_time_get_uptime);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_time_module);
 }

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -493,9 +493,11 @@ c_user_init(void)
 static void DEINIT
 c_user_deinit(void)
 {
-	container_unregister_setuid0_handler();
-	container_unregister_get_uid_handler();
-	container_unregister_open_userns_handler();
+	// unregister handlers implemented by this module
+	container_unregister_setuid0_handler(MOD_NAME, c_user_setuid0);
+	container_unregister_get_uid_handler(MOD_NAME, c_user_get_uid);
+	container_unregister_open_userns_handler(MOD_NAME, c_user_open_userns);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_user_module);
 }

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -2094,10 +2094,12 @@ c_vol_init(void)
 static void DEINIT
 c_vol_deinit(void)
 {
-	container_unregister_get_rootdir_handler();
-	container_unregister_get_mnt_handler();
-	container_unregister_is_encrypted_handler();
-	container_unregister_get_cryptfs_mode_handler();
+	// unregister handlers implemented by this module
+	container_unregister_get_rootdir_handler(MOD_NAME, c_vol_get_rootdir);
+	container_unregister_get_mnt_handler(MOD_NAME, c_vol_get_mnt);
+	container_unregister_is_encrypted_handler(MOD_NAME, c_vol_is_encrypted);
+	container_unregister_get_cryptfs_mode_handler(MOD_NAME, c_vol_get_mode);
 
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_vol_module);
 }

--- a/daemon/c_xorg_compat.c
+++ b/daemon/c_xorg_compat.c
@@ -169,5 +169,6 @@ c_xorg_compat_init(void)
 static void DEINIT
 c_xorg_compat_deinit(void)
 {
+	// unregister this module from container.c
 	container_unregister_compartment_module(&c_xorg_compat_module);
 }

--- a/daemon/container_module.h
+++ b/daemon/container_module.h
@@ -38,7 +38,7 @@
 #define CONTAINER_MODULE_WRAPPER_DECLARE(name, type, ...) \
 	type container_## name(const container_t *container, ##__VA_ARGS__); \
 	void container_register_## name ##_handler(const char *mod_name, type (*h)(void *, ##__VA_ARGS__)); \
-	void container_unregister_## name ##_handler(void);
+	void container_unregister_## name ##_handler(const char *mod_name, type (*h)(void *, ##__VA_ARGS__));
 
 #define CONTAINER_MODULE_REGISTER_WRAPPER_IMPL(name, type, ...) \
 	typedef struct { \
@@ -57,9 +57,11 @@
 		container_## name ##_handler->handler_func = h; \
 		INFO("%s_handler registered by module '%s'.", #name, mod_name); \
 	} \
-	void container_unregister_## name ##_handler(void) \
+	void container_unregister_## name ##_handler(const char *mod_name, type (*h)(__VA_ARGS__)) \
 	{ \
-		if (container_## name ##_handler) { \
+		if (container_## name ##_handler && \
+		    (container_## name ##_handler->mod_name == mod_name) && \
+		    (container_## name ##_handler->handler_func == h)) { \
 			INFO("%s_handler unregistered by module '%s'.", #name, \
 			     container_## name ##_handler->mod_name); \
 			mem_free0(container_## name ##_handler); \


### PR DESCRIPTION
Previously, container_unregister_*_handler() took no arguments and unconditionally freed whatever handler was currently registered. A module's deinit could thus unregister a handler that was registered by a different module (e.g., c_cgroups_dev vs. c_cgroups both provide device_allow handlers).

Change the unregister wrappers generated by container_module.h to take the module name and handler function pointer, and only unregister the handler if both match the currently registered one. Adapt all compartment modules accordingly and add clarifying comments to the init/deinit functions.

Fixes: f6b4b85b858a ("daemon/container: Release compartment_module_list and handlers on exit")