### PR TITLE
common/ssl_util: require OpenSSL >= 3.2 with a clear diagnostic

### DIFF
--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -41,6 +41,18 @@
 #include <openssl/evp.h>
 #include <openssl/params.h>
 
+/*
+ * ssl_init() passes the TPM primary storage key PIN to the libtpm2 provider
+ * via OSSL_PROVIDER_load_ex(), which was introduced in OpenSSL 3.2. On older
+ * OpenSSL the file does not compile at all; fail with a clear message instead
+ * of a cryptic implicit-declaration error. Silently loading the provider
+ * without the PIN is not an option -- it would defer a TPM auth failure to
+ * runtime for the exact (password-protected) case the PIN exists for.
+ */
+#if OPENSSL_VERSION_NUMBER < 0x30200000L
+#error "CML requires OpenSSL >= 3.2 (OSSL_PROVIDER_load_ex for the TPM primary storage key PIN)"
+#endif
+
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
`ssl_init()` loads the libtpm2 provider via `OSSL_PROVIDER_load_ex()` (added in
OpenSSL 3.2) to pass the TPM primary-storage-key PIN through an `OSSL_PARAM`
array. On OpenSSL < 3.2 that function is not declared, so `common/ssl_util.c`
fails to compile with an implicit-function-declaration error.

Add a build-time check that emits a clear `#error` stating the OpenSSL >= 3.2
requirement, so the build fails with an obvious diagnostic instead of an obscure
compiler error.
