### PR TITLE
common: adopt Clang -fbounds-safety annotations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,8 +2,11 @@
 #
 # The changes made to the upstream Linux coding style are:
 # - 100 column limit instead of 80
-# - deleted foreach macros 
-# 
+# - deleted foreach macros
+# - added AttributeMacros for the -fbounds-safety annotation macros
+#   (__counted_by, __sized_by, ...) so clang-format treats them as attributes
+#   and keeps e.g. "void *__sized_by(size)" on the return-type line
+#
 # SPDX-License-Identifier: GPL-2.0
 #
 # clang-format configuration file. Intended for clang-format >= 4.
@@ -32,6 +35,17 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: false
+# -fbounds-safety annotation macros (common/bounds_safety.h); see header note.
+AttributeMacros:
+  - __counted_by
+  - __sized_by
+  - __counted_by_or_null
+  - __sized_by_or_null
+  - __single
+  - __null_terminated
+  - __unsafe_indexable
+  - __terminated_by
+  - __ended_by
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:

--- a/common/Makefile
+++ b/common/Makefile
@@ -63,6 +63,7 @@ endif
 BOUNDS_SAFETY ?= n
 BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c
 BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
+BOUNDS_SAFE_BS_OBJS := $(BOUNDS_SAFE_SRCS:.c=.bs.o)
 
 BOUNDS_CFLAGS := -fbounds-safety -fbounds-safety-bringup-missing-checks=batch_0
 
@@ -142,6 +143,15 @@ sock-sd.o: sock-sd.c
 %.o: %.c
 	$(CC) -c $(LOCAL_CFLAGS) $(EXTRA_CFLAGS) $< -o $@
 
+# Bounds-safe .bs.o objects — always compiled with BOUNDS_CFLAGS.
+# Used exclusively by bounds_test targets to avoid colliding with normal .o files.
+$(BOUNDS_SAFE_BS_OBJS): %.bs.o: %.c
+	$(CC) -c $(LOCAL_CFLAGS) $(BOUNDS_CFLAGS) $< -o $@
+
+# Bounds-test source files — also compiled with BOUNDS_CFLAGS.
+%.bounds_test.o: %.bounds_test.c
+	$(CC) -c $(LOCAL_CFLAGS) $(BOUNDS_CFLAGS) $< -o $@
+
 LFLAGS_TEST := \
 	-L. -lcommon_full \
 	-lssl \
@@ -162,6 +172,21 @@ common.test: $(TEST_SUITES) munit.o common.test.c
 test: libcommon_full common.test
 	./common.test
 
+# Bounds-safety enforcement tests (requires swiftlang Clang fork).
+# Annotated modules are compiled with -fbounds-safety; all others without.
+# Usage: make bounds_test CC=/path/to/bs-clang
+OBJS_BOUNDS_SUPPORT := logf.o list.o dir.o event.o
+
+# All bounds_test binaries — add new ones as modules are annotated.
+BOUNDS_TEST_BINS := hex.bounds_test fd.bounds_test str.bounds_test protobuf.bounds_test file.bounds_test protobuf-text.bounds_test
+
+$(BOUNDS_TEST_BINS): %: %.o $(BOUNDS_SAFE_BS_OBJS) $(OBJS_BOUNDS_SUPPORT)
+	$(CC) $(LOCAL_CFLAGS) -o $@ $^ -lprotobuf-c -lprotobuf-c-text
+
+.PHONY: bounds_test
+bounds_test: $(BOUNDS_TEST_BINS)
+	@for t in $(BOUNDS_TEST_BINS); do echo "=== $$t ==="; ./$$t; done
+
 .PHONY: clean
 clean:
-	rm -f *.o *.a *.pb-c.* common.test
+	rm -f *.o *.a *.pb-c.* common.test $(BOUNDS_TEST_BINS)

--- a/common/Makefile
+++ b/common/Makefile
@@ -61,7 +61,7 @@ endif
 # Only annotated modules are compiled with -fbounds-safety; all others
 # compile normally.  Add newly annotated .c files to BOUNDS_SAFE_SRCS.
 BOUNDS_SAFETY ?= n
-BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c event.c dir.c uuid.c
+BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c event.c dir.c uuid.c proc.c
 BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
 BOUNDS_SAFE_BS_OBJS := $(BOUNDS_SAFE_SRCS:.c=.bs.o)
 

--- a/common/Makefile
+++ b/common/Makefile
@@ -61,7 +61,7 @@ endif
 # Only annotated modules are compiled with -fbounds-safety; all others
 # compile normally.  Add newly annotated .c files to BOUNDS_SAFE_SRCS.
 BOUNDS_SAFETY ?= n
-BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c
+BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c event.c dir.c
 BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
 BOUNDS_SAFE_BS_OBJS := $(BOUNDS_SAFE_SRCS:.c=.bs.o)
 
@@ -175,7 +175,7 @@ test: libcommon_full common.test
 # Bounds-safety enforcement tests (requires swiftlang Clang fork).
 # Annotated modules are compiled with -fbounds-safety; all others without.
 # Usage: make bounds_test CC=/path/to/bs-clang
-OBJS_BOUNDS_SUPPORT := logf.o list.o dir.o event.o
+OBJS_BOUNDS_SUPPORT := logf.o list.o
 
 # All bounds_test binaries — add new ones as modules are annotated.
 BOUNDS_TEST_BINS := hex.bounds_test fd.bounds_test str.bounds_test protobuf.bounds_test file.bounds_test protobuf-text.bounds_test

--- a/common/Makefile
+++ b/common/Makefile
@@ -61,7 +61,7 @@ endif
 # Only annotated modules are compiled with -fbounds-safety; all others
 # compile normally.  Add newly annotated .c files to BOUNDS_SAFE_SRCS.
 BOUNDS_SAFETY ?= n
-BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c
+BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c
 BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
 
 BOUNDS_CFLAGS := -fbounds-safety -fbounds-safety-bringup-missing-checks=batch_0

--- a/common/Makefile
+++ b/common/Makefile
@@ -61,7 +61,7 @@ endif
 # Only annotated modules are compiled with -fbounds-safety; all others
 # compile normally.  Add newly annotated .c files to BOUNDS_SAFE_SRCS.
 BOUNDS_SAFETY ?= n
-BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c event.c dir.c
+BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c event.c dir.c uuid.c
 BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
 BOUNDS_SAFE_BS_OBJS := $(BOUNDS_SAFE_SRCS:.c=.bs.o)
 

--- a/common/Makefile
+++ b/common/Makefile
@@ -61,7 +61,7 @@ endif
 # Only annotated modules are compiled with -fbounds-safety; all others
 # compile normally.  Add newly annotated .c files to BOUNDS_SAFE_SRCS.
 BOUNDS_SAFETY ?= n
-BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c
+BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c sock.c protobuf-text.c
 BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
 
 BOUNDS_CFLAGS := -fbounds-safety -fbounds-safety-bringup-missing-checks=batch_0

--- a/common/Makefile
+++ b/common/Makefile
@@ -57,6 +57,18 @@ ifeq ($(SANITIZERS),y)
     # to be installed on the build host
     LOCAL_CFLAGS += -lasan -fsanitize=address -fsanitize=undefined -fsanitize-recover=address
 endif
+# --- Per-module bounds-safety support ---
+# Only annotated modules are compiled with -fbounds-safety; all others
+# compile normally.  Add newly annotated .c files to BOUNDS_SAFE_SRCS.
+BOUNDS_SAFETY ?= n
+BOUNDS_SAFE_SRCS := hex.c mem.c fd.c str.c protobuf.c file.c
+BOUNDS_SAFE_OBJS := $(BOUNDS_SAFE_SRCS:.c=.o)
+
+BOUNDS_CFLAGS := -fbounds-safety -fbounds-safety-bringup-missing-checks=batch_0
+
+ifeq ($(BOUNDS_SAFETY),y)
+$(BOUNDS_SAFE_OBJS): EXTRA_CFLAGS := $(BOUNDS_CFLAGS)
+endif
 
 .PHONY: all
 all: libcommon
@@ -125,10 +137,10 @@ libcommon_full_systemd: $(OBJS_COMMON_FULL) sock-sd.o
 	$(AR) rcs libcommon_full_systemd.a $^
 
 sock-sd.o: sock-sd.c
-	$(CC) -c $(LOCAL_CFLAGS) -DSYSTEMD $< -o $@
+	$(CC) -c $(LOCAL_CFLAGS) $(EXTRA_CFLAGS) -DSYSTEMD $< -o $@
 
 %.o: %.c
-	$(CC) -c $(LOCAL_CFLAGS) $< -o $@
+	$(CC) -c $(LOCAL_CFLAGS) $(EXTRA_CFLAGS) $< -o $@
 
 LFLAGS_TEST := \
 	-L. -lcommon_full \

--- a/common/README.md
+++ b/common/README.md
@@ -54,3 +54,17 @@ new module, add its `.c` filename to `BOUNDS_SAFE_SRCS`.
 # Build with bounds enforcement on annotated modules
 make CC=/home/node/llvm-bs/build/bin/clang BOUNDS_SAFETY=y
 ```
+
+### Enforcement tests
+
+Enforcement tests (`*.bounds_test.c`) verify that out-of-bounds access
+actually traps at runtime. They fork a child process that deliberately
+violates declared bounds; the parent asserts the child was killed by a
+signal.
+
+```bash
+make bounds_test CC=/home/node/llvm-bs/build/bin/clang
+```
+
+Without the bounds-safety toolchain, these tests print `SKIP` and exit
+with code 77.

--- a/common/README.md
+++ b/common/README.md
@@ -4,3 +4,53 @@
 - This directory is typically symlinked into other projects.
 - Also contains sources for a C unit testing framework - munit.h and munit.c
 - munit.h and munit.c are fork of https://nemequ.github.io/munit/
+
+## Building the `-fbounds-safety` toolchain
+
+Full `-fbounds-safety` enforcement is not yet in upstream LLVM. The working
+implementation lives in the [swiftlang Clang fork](https://github.com/swiftlang/llvm-project).
+Requires `cmake` and `ninja-build`.
+
+```bash
+# Clone (blobless shallow clone, ~2 min)
+git clone --depth 1 --branch stable/21.x --filter=blob:none \
+  https://github.com/swiftlang/llvm-project.git /home/node/llvm-bs
+
+# Configure (Clang only, Release, host architecture)
+cmake -G Ninja -S /home/node/llvm-bs/llvm -B /home/node/llvm-bs/build \
+  -DLLVM_ENABLE_PROJECTS="clang" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_TARGETS_TO_BUILD="Native" \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_DOCS=OFF
+
+# Build (~15 min on 8 cores)
+cmake --build /home/node/llvm-bs/build --target clang -- -j$(nproc)
+```
+
+The resulting Clang binary accepts `-fbounds-safety`. The `BOUNDS_SAFETY`
+Makefile flag wires this into the build:
+
+```bash
+make CC=/home/node/llvm-bs/build/bin/clang BOUNDS_SAFETY=y
+```
+
+## Bounds-safety annotations
+
+Selected modules are annotated with `-fbounds-safety` attributes
+(`__counted_by`, `__sized_by`, etc.) on pointer/size parameter pairs.
+The compatibility header `bounds_safety.h` includes `<ptrcheck.h>` from
+the swiftlang Clang fork when available, falling back to no-op
+definitions on GCC and stock Clang. Annotated code builds everywhere.
+
+**Annotated modules:** `hex.c/h` (pilot). Listed in `BOUNDS_SAFE_SRCS`
+in the Makefile. When `BOUNDS_SAFETY=y`, only these files are compiled
+with `-fbounds-safety`; all other files compile normally. To annotate a
+new module, add its `.c` filename to `BOUNDS_SAFE_SRCS`.
+
+```bash
+# Build with bounds enforcement on annotated modules
+make CC=/home/node/llvm-bs/build/bin/clang BOUNDS_SAFETY=y
+```

--- a/common/README.md
+++ b/common/README.md
@@ -12,12 +12,15 @@ implementation lives in the [swiftlang Clang fork](https://github.com/swiftlang/
 Requires `cmake` and `ninja-build`.
 
 ```bash
+# Pick a location for the toolchain checkout/build (adjust to taste)
+export LLVM_BS_DIR="$HOME/llvm-bs"
+
 # Clone (blobless shallow clone, ~2 min)
-git clone --depth 1 --branch stable/21.x --filter=blob:none \
-  https://github.com/swiftlang/llvm-project.git /home/node/llvm-bs
+git clone --depth 1 --branch stable/20260609 --filter=blob:none \
+  https://github.com/swiftlang/llvm-project.git "$LLVM_BS_DIR"
 
 # Configure (Clang only, Release, host architecture)
-cmake -G Ninja -S /home/node/llvm-bs/llvm -B /home/node/llvm-bs/build \
+cmake -G Ninja -S "$LLVM_BS_DIR/llvm" -B "$LLVM_BS_DIR/build" \
   -DLLVM_ENABLE_PROJECTS="clang" \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_TARGETS_TO_BUILD="Native" \
@@ -27,14 +30,14 @@ cmake -G Ninja -S /home/node/llvm-bs/llvm -B /home/node/llvm-bs/build \
   -DLLVM_INCLUDE_DOCS=OFF
 
 # Build (~15 min on 8 cores)
-cmake --build /home/node/llvm-bs/build --target clang -- -j$(nproc)
+cmake --build "$LLVM_BS_DIR/build" --target clang -- -j$(nproc)
 ```
 
 The resulting Clang binary accepts `-fbounds-safety`. The `BOUNDS_SAFETY`
 Makefile flag wires this into the build:
 
 ```bash
-make CC=/home/node/llvm-bs/build/bin/clang BOUNDS_SAFETY=y
+make CC="$LLVM_BS_DIR/build/bin/clang" BOUNDS_SAFETY=y
 ```
 
 ## Bounds-safety annotations
@@ -52,7 +55,7 @@ new module, add its `.c` filename to `BOUNDS_SAFE_SRCS`.
 
 ```bash
 # Build with bounds enforcement on annotated modules
-make CC=/home/node/llvm-bs/build/bin/clang BOUNDS_SAFETY=y
+make CC="$LLVM_BS_DIR/build/bin/clang" BOUNDS_SAFETY=y
 ```
 
 ### Enforcement tests
@@ -63,7 +66,7 @@ violates declared bounds; the parent asserts the child was killed by a
 signal.
 
 ```bash
-make bounds_test CC=/home/node/llvm-bs/build/bin/clang
+make bounds_test CC="$LLVM_BS_DIR/build/bin/clang"
 ```
 
 Without the bounds-safety toolchain, these tests print `SKIP` and exit

--- a/common/bounds_safety.h
+++ b/common/bounds_safety.h
@@ -42,11 +42,11 @@
 #define BOUNDS_SAFETY_H
 
 #if defined(__has_include) && __has_include(<ptrcheck.h>)
-  /* swiftlang Clang fork: <ptrcheck.h> provides real annotations when
+/* swiftlang Clang fork: <ptrcheck.h> provides real annotations when
    * -fbounds-safety is active and comprehensive no-ops when it is not. */
-  #include <ptrcheck.h>
+#include <ptrcheck.h>
 #else
-  /* GCC or stock Clang without ptrcheck.h: annotations are no-ops.
+/* GCC or stock Clang without ptrcheck.h: annotations are no-ops.
    *
    * The __counted_by/__sized_by family is guarded with #ifndef: the Linux
    * UAPI header <linux/stddef.h> (kernel >= 6.11) also defines __counted_by
@@ -54,41 +54,43 @@
    * redefinition here trips -Wmacro-redefined under -Werror whenever a
    * translation unit pulls in a UAPI header before this one.  Cooperate the
    * same way the kernel header does and defer to any existing definition. */
-  #ifndef __counted_by
-  #define __counted_by(N)
-  #endif
-  #ifndef __sized_by
-  #define __sized_by(N)
-  #endif
-  #ifndef __counted_by_or_null
-  #define __counted_by_or_null(N)
-  #endif
-  #ifndef __sized_by_or_null
-  #define __sized_by_or_null(N)
-  #endif
-  #define __ended_by(E)
-  #define __single
-  #define __null_terminated
-  #define __unsafe_indexable
-  #define __terminated_by(T)
-  #define __unsafe_forge_single(T, P) ((T)(P))
-  #define __unsafe_forge_bidi_indexable(T, P, S) ((T)(P))
-  #define __unsafe_forge_null_terminated(T, P) ((T)(P))
-  #define __BOUNDS_SAFETY_IGNORE_REST(P, ...) (P)
-  #define __unsafe_terminated_by_from_indexable(T, ...) \
-    __BOUNDS_SAFETY_IGNORE_REST(__VA_ARGS__, ((void)0))
-  #define __unsafe_null_terminated_from_indexable(...) \
-    __unsafe_terminated_by_from_indexable(0, __VA_ARGS__)
-  #define __ptrcheck_abi_assume_single()
-  #define __ptrcheck_abi_assume_unsafe_indexable()
-  #define __array_decay_discards_count_in_parameters
+#ifndef __counted_by
+#define __counted_by(N)
+#endif
+#ifndef __sized_by
+#define __sized_by(N)
+#endif
+#ifndef __counted_by_or_null
+#define __counted_by_or_null(N)
+#endif
+#ifndef __sized_by_or_null
+#define __sized_by_or_null(N)
+#endif
+#define __ended_by(E)
+#define __single
+#define __null_terminated
+#define __unsafe_indexable
+#define __terminated_by(T)
+#define __unsafe_forge_single(T, P) ((T)(P))
+#define __unsafe_forge_bidi_indexable(T, P, S) ((T)(P))
+#define __unsafe_forge_null_terminated(T, P) ((T)(P))
+#define __BOUNDS_SAFETY_IGNORE_REST(P, ...) (P)
+#define __unsafe_terminated_by_from_indexable(T, ...)                                              \
+	__BOUNDS_SAFETY_IGNORE_REST(__VA_ARGS__, ((void)0))
+#define __unsafe_null_terminated_from_indexable(...)                                               \
+	__unsafe_terminated_by_from_indexable(0, __VA_ARGS__)
+#define __null_terminated_to_indexable(P) (P)
+#define __unsafe_null_terminated_to_indexable(P) (P)
+#define __ptrcheck_abi_assume_single()
+#define __ptrcheck_abi_assume_unsafe_indexable()
+#define __array_decay_discards_count_in_parameters
 #endif
 
 /* Set when full enforcement is active (bounds_test files gate on this). */
 #ifdef __clang__
-  #if __has_feature(bounds_safety)
-    #define BOUNDS_SAFETY_ENABLED 1
-  #endif
+#if __has_feature(bounds_safety)
+#define BOUNDS_SAFETY_ENABLED 1
+#endif
 #endif
 
 #endif /* BOUNDS_SAFETY_H */

--- a/common/bounds_safety.h
+++ b/common/bounds_safety.h
@@ -1,0 +1,94 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file bounds_safety.h
+ *
+ * Compatibility header for Clang's -fbounds-safety annotations.
+ *
+ * When compiled with the swiftlang Clang fork (which ships <ptrcheck.h>),
+ * this header simply includes <ptrcheck.h>, which provides both real
+ * annotations (under -fbounds-safety) and no-op fallbacks (without it).
+ * On GCC or stock Clang where <ptrcheck.h> is absent, this header defines
+ * all annotations as no-ops, preserving full build compatibility.
+ *
+ * Usage: include this header before using any bounds annotations in .h or .c
+ * files. Annotate pointer parameters that have an associated size argument:
+ *
+ *   void foo(const char *__counted_by(len) buf, size_t len);
+ */
+
+#ifndef BOUNDS_SAFETY_H
+#define BOUNDS_SAFETY_H
+
+#if defined(__has_include) && __has_include(<ptrcheck.h>)
+  /* swiftlang Clang fork: <ptrcheck.h> provides real annotations when
+   * -fbounds-safety is active and comprehensive no-ops when it is not. */
+  #include <ptrcheck.h>
+#else
+  /* GCC or stock Clang without ptrcheck.h: annotations are no-ops.
+   *
+   * The __counted_by/__sized_by family is guarded with #ifndef: the Linux
+   * UAPI header <linux/stddef.h> (kernel >= 6.11) also defines __counted_by
+   * (as an empty no-op) for flexible-array members, so an unconditional
+   * redefinition here trips -Wmacro-redefined under -Werror whenever a
+   * translation unit pulls in a UAPI header before this one.  Cooperate the
+   * same way the kernel header does and defer to any existing definition. */
+  #ifndef __counted_by
+  #define __counted_by(N)
+  #endif
+  #ifndef __sized_by
+  #define __sized_by(N)
+  #endif
+  #ifndef __counted_by_or_null
+  #define __counted_by_or_null(N)
+  #endif
+  #ifndef __sized_by_or_null
+  #define __sized_by_or_null(N)
+  #endif
+  #define __ended_by(E)
+  #define __single
+  #define __null_terminated
+  #define __unsafe_indexable
+  #define __terminated_by(T)
+  #define __unsafe_forge_single(T, P) ((T)(P))
+  #define __unsafe_forge_bidi_indexable(T, P, S) ((T)(P))
+  #define __unsafe_forge_null_terminated(T, P) ((T)(P))
+  #define __BOUNDS_SAFETY_IGNORE_REST(P, ...) (P)
+  #define __unsafe_terminated_by_from_indexable(T, ...) \
+    __BOUNDS_SAFETY_IGNORE_REST(__VA_ARGS__, ((void)0))
+  #define __unsafe_null_terminated_from_indexable(...) \
+    __unsafe_terminated_by_from_indexable(0, __VA_ARGS__)
+  #define __ptrcheck_abi_assume_single()
+  #define __ptrcheck_abi_assume_unsafe_indexable()
+  #define __array_decay_discards_count_in_parameters
+#endif
+
+/* Set when full enforcement is active (bounds_test files gate on this). */
+#ifdef __clang__
+  #if __has_feature(bounds_safety)
+    #define BOUNDS_SAFETY_ENABLED 1
+  #endif
+#endif
+
+#endif /* BOUNDS_SAFETY_H */

--- a/common/bounds_test.h
+++ b/common/bounds_test.h
@@ -1,0 +1,156 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file bounds_test.h
+ *
+ * Shared harness for the standalone -fbounds-safety enforcement tests
+ * (the common/ *.bounds_test.c files).
+ *
+ * Each test file defines a set of violate_*() functions that deliberately call
+ * a bounds-annotated function with a length larger than the real buffer, plus a
+ * NULL-terminated cases[] array pairing each with a name.  The file then invokes
+ * BOUNDS_TEST_MAIN() to generate its entry point.
+ *
+ * Without the swiftlang Clang fork (i.e. BOUNDS_SAFETY_ENABLED undefined),
+ * BOUNDS_TEST_MAIN() expands to a stub main() that prints SKIP and returns 77
+ * (autotools-style skip exit code); the file's violate_*()/cases[] should live
+ * inside an #ifdef BOUNDS_SAFETY_ENABLED so they are not compiled there.
+ *
+ * With -fbounds-safety active, it expands to a runner that forks each violation
+ * in a child and asserts the child was killed by a signal (the bounds trap).
+ *
+ * Typical usage:
+ *   #include "bounds_test.h"
+ *   #include "hex.h"
+ *   #include "mem.h"
+ *
+ *   #ifdef BOUNDS_SAFETY_ENABLED
+ *   static void violate_foo(void) { ... }
+ *   static struct bounds_test_case cases[] = {
+ *           { "foo OOB", violate_foo },
+ *           { NULL, NULL }
+ *   };
+ *   #endif
+ *
+ *   BOUNDS_TEST_MAIN("hex.bounds_test", cases)
+ */
+
+#ifndef BOUNDS_TEST_H
+#define BOUNDS_TEST_H
+
+#include "bounds_safety.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef BOUNDS_SAFETY_ENABLED
+
+/*
+ * Built without -fbounds-safety: emit a stub that skips.  cases_array is
+ * intentionally not referenced, so it need not exist in this build.
+ */
+#define BOUNDS_TEST_MAIN(module, cases_array)                                                      \
+	int main(void)                                                                             \
+	{                                                                                          \
+		fprintf(stderr,                                                                    \
+			"SKIP: " module " requires -fbounds-safety.\n"                             \
+			"Build with: CC=/path/to/bs-clang BOUNDS_SAFETY=y make bounds_test\n");    \
+		return 77; /* autotools-style skip exit code */                                    \
+	}
+
+#else
+
+typedef void (*bounds_violation_fn)(void);
+
+struct bounds_test_case {
+	const char *name;
+	bounds_violation_fn fn;
+};
+
+/*
+ * Fork a child that calls fn().  Returns 1 if the child was killed by a
+ * signal (bounds-safety trap), 0 if it exited normally, -1 on error.
+ */
+static int
+expect_trap(bounds_violation_fn fn)
+{
+	fflush(stdout);
+	fflush(stderr);
+	pid_t pid = fork();
+	if (pid < 0)
+		return -1;
+	if (pid == 0) {
+		fn();
+		_exit(0);
+	}
+	int status;
+	if (waitpid(pid, &status, 0) < 0)
+		return -1;
+	return WIFSIGNALED(status) ? 1 : 0;
+}
+
+/*
+ * Run every case: a case passes only if its violation trapped.  Returns 1 if
+ * any case failed to trap (or errored), 0 if all trapped.  n counts the array
+ * entries (including the { NULL, NULL } sentinel, on which iteration stops).
+ */
+static int __attribute__((unused))
+bounds_test_run(struct bounds_test_case *__counted_by(n) cases, size_t n)
+{
+	int passed = 0;
+	int failed = 0;
+
+	for (size_t i = 0; i < n && cases[i].name; i++) {
+		int r = expect_trap(cases[i].fn);
+		if (r == 1) {
+			printf("  PASS  %s (trapped)\n", cases[i].name);
+			passed++;
+		} else if (r == 0) {
+			printf("  FAIL  %s (no trap — bounds not enforced)\n", cases[i].name);
+			failed++;
+		} else {
+			printf("  ERROR %s (fork/wait failed)\n", cases[i].name);
+			failed++;
+		}
+	}
+
+	printf("\n%d passed, %d failed\n", passed, failed);
+	return failed ? 1 : 0;
+}
+
+#define BOUNDS_TEST_MAIN(module, cases_array)                                                      \
+	int main(void)                                                                             \
+	{                                                                                          \
+		(void)module;                                                                      \
+		return bounds_test_run(cases_array,                                                \
+				       sizeof(cases_array) / sizeof((cases_array)[0]));            \
+	}
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+#endif /* BOUNDS_TEST_H */

--- a/common/cryptfs.c
+++ b/common/cryptfs.c
@@ -567,7 +567,8 @@ cryptfs_write_zeros(char *crypto_blkdev, size_t size)
 {
 	int fd = -1, ret = -1;
 	char *zeros = NULL;
-	ssize_t towrite = -1, res = -1, written = 0;
+	size_t towrite = 0;
+	ssize_t res = -1, written = 0;
 
 	IF_NULL_RETVAL(crypto_blkdev, -1);
 
@@ -585,10 +586,10 @@ cryptfs_write_zeros(char *crypto_blkdev, size_t size)
 		towrite = MIN(size - written, ZERO_BUF_SIZE);
 
 		if (0 > (res = fd_write(fd, zeros, towrite))) {
-			ERROR("Failed to write: %zd bytes", towrite);
+			ERROR("Failed to write: %zu bytes", towrite);
 			goto error;
 		}
-		TRACE("res: %zd, written %zd, towrite %zd\n", res, written, towrite);
+		TRACE("res: %zd, written %zd, towrite %zu\n", res, written, towrite);
 
 		written += res;
 	}

--- a/common/dir.c
+++ b/common/dir.c
@@ -22,6 +22,8 @@
  */
 
 #include "dir.h"
+
+#include "bounds_safety.h"
 #include "file.h"
 
 #include "macro.h"
@@ -38,28 +40,30 @@ int
 dir_foreach(const char *path, int (*func)(const char *path, const char *file, void *data),
 	    void *data)
 {
-	struct dirent *dp;
-	DIR *dirp;
+	struct dirent *__single dp;
+	DIR *__single dirp;
 	int n = 0;
 
 	IF_NULL_RETVAL(path, -1);
 	IF_NULL_RETVAL(func, -1);
 
-	dirp = opendir(path);
+	dirp = __unsafe_forge_single(DIR *, opendir(path));
 	if (!dirp) {
 		WARN_ERRNO("Could not open dir %s", path);
 		return -1;
 	}
 
-	while ((dp = readdir(dirp)) != NULL) {
-		if (strcmp(dp->d_name, ".") == 0)
+	while ((dp = __unsafe_forge_single(struct dirent *, readdir(dirp))) != NULL) {
+		const char *__null_terminated name =
+			__unsafe_forge_null_terminated(const char *, dp->d_name);
+		if (strcmp(name, ".") == 0)
 			continue;
-		if (strcmp(dp->d_name, "..") == 0)
+		if (strcmp(name, "..") == 0)
 			continue;
 
-		TRACE("Found directory %s/%s", path, dp->d_name);
+		TRACE("Found directory %s/%s", path, name);
 
-		int ret = func(path, dp->d_name, data);
+		int ret = func(path, name, data);
 		if (ret < 0) {
 			DEBUG("Callback of dir_foreach returned %d", ret);
 			n = -1;
@@ -78,18 +82,18 @@ int
 dir_mkdir_p(const char *path, mode_t mode)
 {
 	ASSERT(path);
-	char *c, *p = mem_printf("%s", path);
+	char *__null_terminated c, *__null_terminated p = mem_printf("%s", path);
 	c = p;
 	int ret = 0;
 
 	//DEBUG("Doing mkdir -p on path %s", p);
 	mode_t old_mask = umask(0);
 
-	if (c[0] == '/') {
+	if (*c == '/') {
 		c++;
 	}
 
-	c = strchr(c, '/');
+	c = __unsafe_forge_null_terminated(char *, strchr(c, '/'));
 	while (c) {
 		*c = '\0';
 		//DEBUG("Doing mkdir on path %s", p);
@@ -99,7 +103,8 @@ dir_mkdir_p(const char *path, mode_t mode)
 			goto out;
 		}
 		*c = '/';
-		c = strchr(c + 1, '/');
+		c++;
+		c = __unsafe_forge_null_terminated(char *, strchr(c, '/'));
 	}
 	if (mkdir(p, mode) < 0 && errno != EEXIST) {
 		ERROR_ERRNO("Could not mkdir %s", p);
@@ -130,7 +135,7 @@ dir_unlink_folder_contents_cb(const char *path, const char *name, UNUSED void *d
 	}
 
 	if (S_ISDIR(stat_buffer.st_mode)) {
-		char *subdir = mem_printf("%s/%s", path, name);
+		char *__null_terminated subdir = mem_printf("%s/%s", path, name);
 		TRACE("Path %s is dir", subdir);
 		if (dir_foreach(subdir, &dir_unlink_folder_contents_cb, NULL) < 0) {
 			ERROR_ERRNO("Could not delete all dir contents in %s", subdir);
@@ -158,7 +163,7 @@ int
 dir_delete_folder(const char *path, const char *dir_name)
 {
 	int ret = 0;
-	char *dir_to_remove = mem_printf("%s/%s", path, dir_name);
+	char *__null_terminated dir_to_remove = mem_printf("%s/%s", path, dir_name);
 
 	DEBUG("Deleting %s", dir_to_remove);
 	if (dir_foreach(dir_to_remove, &dir_unlink_folder_contents_cb, NULL) < 0) {
@@ -176,7 +181,7 @@ dir_delete_folder(const char *path, const char *dir_name)
 }
 
 typedef struct dir_copy_params {
-	char *target;
+	char *__null_terminated target;
 	void *data;
 	bool (*filter)(const char *file, void *data);
 } dir_copy_params_t;
@@ -201,15 +206,15 @@ dir_copy_params_free(dir_copy_params_t *params)
 static int
 dir_copy_folder_contents_cb(const char *path, const char *name, void *data)
 {
-	dir_copy_params_t *p = data;
+	dir_copy_params_t *__single p = data;
 	ASSERT(p);
 
 	struct stat s;
 
 	int ret = 0;
-	char *file_src = mem_printf("%s/%s", path, name);
+	char *__null_terminated file_src = mem_printf("%s/%s", path, name);
 	dir_copy_params_t *params = dir_copy_params_new(p->target, name, p->filter, p->data);
-	char *file_dst = params->target;
+	char *__null_terminated file_dst = params->target;
 
 	IF_NULL_GOTO_ERROR(file_dst, out);
 
@@ -325,10 +330,10 @@ dir_chown_contents_cb(const char *path, const char *file, void *data)
 {
 	struct stat s;
 	int ret = 0;
-	struct chown_data *cb_data = data;
+	struct chown_data *__single cb_data = data;
 	ASSERT(cb_data);
 
-	char *file_to_chown = mem_printf("%s/%s", path, file);
+	char *__null_terminated file_to_chown = mem_printf("%s/%s", path, file);
 	if (lstat(file_to_chown, &s) == -1) {
 		mem_free0(file_to_chown);
 		return -1;

--- a/common/event.c
+++ b/common/event.c
@@ -25,6 +25,7 @@
 
 #include "event.h"
 
+#include "bounds_safety.h"
 #include "mem.h"
 #include "list.h"
 #include "macro.h"
@@ -95,12 +96,12 @@ struct event_io {
 
 struct event_inotify {
 	void (*func)(const char *path, uint32_t mask, event_inotify_t *inotify,
-		     void *data); /**< the function to call when the event is triggered */
-	void *data;		  /**< a data pointer to pass to the callback function */
-	char *path;		  /**< the path to be watched */
-	uint32_t mask;		  /**< a bit-mask of events to be watched for */
-	int wd;			  /**< the watch descriptor */
-	bool todo;		  /**< helper variable for event_inotify_handler() */
+		     void *data);     /**< the function to call when the event is triggered */
+	void *data;		      /**< a data pointer to pass to the callback function */
+	char *__null_terminated path; /**< the path to be watched */
+	uint32_t mask;		      /**< a bit-mask of events to be watched for */
+	int wd;			      /**< the watch descriptor */
+	bool todo;		      /**< helper variable for event_inotify_handler() */
 };
 
 struct event_signal {
@@ -116,7 +117,7 @@ static list_t *event_signal_list = NULL;
 static list_t *event_inotify_list = NULL;
 static bool event_signal_received0[NSIG] = { false };
 static bool event_signal_received1[NSIG] = { false };
-static bool *event_signal_received = event_signal_received0;
+static bool *__counted_by(NSIG) event_signal_received = event_signal_received0;
 static unsigned event_io_active = 0;
 static bool event_initialized = false;
 static event_io_t *event_inotify_io = NULL;
@@ -127,7 +128,7 @@ static int
 event_timeout(void)
 {
 	struct timespec next, now, diff;
-	event_timer_t *timer;
+	event_timer_t *__single timer;
 	list_t *l;
 
 	if (!event_timer_list)
@@ -174,7 +175,7 @@ event_timeout_handler(void)
 	timespec_now(&now);
 
 	for (list_t *l = event_timer_list; l;) {
-		event_timer_t *timer = l->data;
+		event_timer_t *__single timer = l->data;
 
 		ASSERT(timer);
 
@@ -417,7 +418,8 @@ event_epoll(int timeout)
 
 	} else if (n > 0) {
 		for (i = 0; i < n; i++) {
-			event_io_t *io = epoll_events[i].data.ptr;
+			event_io_t *__single io =
+				__unsafe_forge_single(event_io_t *, epoll_events[i].data.ptr);
 			uint32_t events = epoll_events[i].events;
 			unsigned e;
 
@@ -449,7 +451,7 @@ static void
 event_inotify_handler(int wd, const char *path, uint32_t mask)
 {
 	for (list_t *l = event_inotify_list; l; l = l->next) {
-		event_inotify_t *inotify = l->data;
+		event_inotify_t *__single inotify = l->data;
 
 		ASSERT(inotify);
 
@@ -458,7 +460,7 @@ event_inotify_handler(int wd, const char *path, uint32_t mask)
 	}
 
 	for (list_t *l = event_inotify_list; l;) {
-		event_inotify_t *inotify = l->data;
+		event_inotify_t *__single inotify = l->data;
 
 		ASSERT(inotify);
 
@@ -472,7 +474,8 @@ event_inotify_handler(int wd, const char *path, uint32_t mask)
 			      wd, inotify->path, inotify->mask);
 
 			if (path) {
-				char *full_path = mem_printf("%s/%s", inotify->path, path);
+				char *__null_terminated full_path =
+					mem_printf("%s/%s", inotify->path, path);
 				(inotify->func)(full_path, mask, inotify, inotify->data);
 				mem_free0(full_path);
 			} else {
@@ -510,7 +513,8 @@ event_inotify_cb(int fd, unsigned events, UNUSED event_io_t *io, UNUSED void *da
 	for (p = buf; p < buf + n;) {
 		ASSERT((uintptr_t)p % __alignof__(struct inotify_event) == 0);
 		struct inotify_event *e = (struct inotify_event *)(void *)p;
-		const char *name = e->len ? e->name : NULL;
+		const char *__null_terminated name =
+			e->len ? __unsafe_forge_null_terminated(const char *, e->name) : NULL;
 
 		TRACE("Read inotify event %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
 		      "(wd=%d, mask=0x%08x, cookie=0x%08x, name=%s)",
@@ -655,7 +659,7 @@ event_remove_inotify(event_inotify_t *inotify)
 	 * watch descriptor */
 	bool others = false;
 	for (list_t *l = event_inotify_list; l; l = l->next) {
-		event_inotify_t *inotify_cur = l->data;
+		event_inotify_t *__single inotify_cur = l->data;
 		if (inotify_cur->wd == inotify->wd) {
 			if (!others)
 				/* If the handler is the first of the others it should overwrite the mask */
@@ -741,8 +745,6 @@ event_remove_signal(event_signal_t *sig)
 static void
 event_signal_handler(void)
 {
-	bool *received;
-
 	TRACE("event_signal_handler() called");
 
 	/* We have two arrays to allow atomic switching from one array to the
@@ -750,14 +752,14 @@ event_signal_handler(void)
 	 * possible that the handler is only called once for multiple signals
 	 * of the same type.
 	 */
-	received = event_signal_received;
+	bool *__counted_by(NSIG) received = event_signal_received;
 	if (event_signal_received == event_signal_received0)
 		event_signal_received = event_signal_received1;
 	else
 		event_signal_received = event_signal_received0;
 
 	for (list_t *l = event_signal_list; l; l = l->next) {
-		event_signal_t *sig = l->data;
+		event_signal_t *__single sig = l->data;
 
 		ASSERT(sig);
 
@@ -766,7 +768,7 @@ event_signal_handler(void)
 	}
 
 	for (list_t *l = event_signal_list; l;) {
-		event_signal_t *sig = l->data;
+		event_signal_t *__single sig = l->data;
 
 		ASSERT(sig);
 		ASSERT(sig->signum > 0);

--- a/common/fd.bounds_test.c
+++ b/common/fd.bounds_test.c
@@ -1,0 +1,124 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file fd.bounds_test.c
+ *
+ * Standalone bounds-safety enforcement tests for fd.c.
+ *
+ * Must be compiled with the swiftlang Clang fork and -fbounds-safety.
+ * Uses fork() to test that out-of-bounds access traps at runtime.
+ * Dynamic (malloc'd) buffer sizes force runtime checks — the compiler
+ * cannot catch these statically.
+ *
+ * Build:
+ *   make bounds_test CC=/path/to/bs-clang
+ */
+
+#include "bounds_test.h"
+#include "fd.h"
+#include "mem.h"
+
+#ifdef BOUNDS_SAFETY_ENABLED
+
+/* Prevent the compiler from constant-folding sizes. */
+static volatile size_t dynamic_4 = 4;
+static volatile size_t dynamic_16 = 16;
+
+/* Sink to prevent optimising away the call. */
+static volatile int sink;
+
+/*
+ * Each violation allocates a buffer of real size N, then calls an fd
+ * function claiming size > N.  The runtime bounds check at the call
+ * site should trap.
+ *
+ * We use pipe() to create valid file descriptors for read/write.
+ */
+
+static void
+violate_fd_write(void)
+{
+	int pipefd[2];
+	if (pipe(pipefd) < 0)
+		_exit(2);
+
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	memcpy(buf, "test", 4);
+	/* buf has 4 bytes, but we claim len=16 → trap */
+	sink = (int)fd_write(pipefd[1], buf, dynamic_16);
+
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+static void
+violate_fd_read(void)
+{
+	int pipefd[2];
+	if (pipe(pipefd) < 0)
+		_exit(2);
+
+	/* Write some data so read has something to consume. */
+	const char *data = "0123456789abcdef";
+	write(pipefd[1], data, 16);
+
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	/* buf has 4 bytes, but we claim len=16 → trap */
+	sink = fd_read(pipefd[0], buf, dynamic_16);
+
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+static void
+violate_fd_read_blockwise(void)
+{
+	int pipefd[2];
+	if (pipe(pipefd) < 0)
+		_exit(2);
+
+	/* Write enough data for the read. */
+	const char *data = "0123456789abcdef";
+	write(pipefd[1], data, 16);
+
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	/* buf has 4 bytes, but we claim len=16 → trap */
+	sink = (int)fd_read_blockwise(pipefd[0], buf, dynamic_16, 4, 4);
+
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+static struct bounds_test_case cases[] = { { "fd_write OOB buf", violate_fd_write },
+					   { "fd_read OOB buf", violate_fd_read },
+					   { "fd_read_blockwise OOB buf",
+					     violate_fd_read_blockwise },
+					   { NULL, NULL } };
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+BOUNDS_TEST_MAIN("fd.bounds_test", cases)

--- a/common/fd.c
+++ b/common/fd.c
@@ -34,7 +34,7 @@
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
 ssize_t
-fd_write(int fd, const char *buf, ssize_t len)
+fd_write(int fd, const char *buf, size_t len)
 {
 	size_t remain = len;
 

--- a/common/fd.c
+++ b/common/fd.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "bounds_safety.h"
 #include "mem.h"
 #include "macro.h"
 #include "fd.h"
@@ -34,14 +35,18 @@
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
 ssize_t
-fd_write(int fd, const char *buf, size_t len)
+fd_write(int fd, const char *__counted_by(len) buf, size_t len)
 {
+	if (len == 0)
+		return 0;
+
+	const char *pos = buf;
 	size_t remain = len;
 
 	while (remain > 0) {
 		int ret;
 
-		ret = write(fd, buf, remain);
+		ret = write(fd, pos, remain);
 
 		if (ret < 0) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -57,7 +62,7 @@ fd_write(int fd, const char *buf, size_t len)
 		}
 
 		remain -= ret;
-		buf += ret;
+		pos += ret;
 		TRACE("Writing to fd %d: Wrote %d bytes, %zu bytes remaining.", fd, ret, remain);
 
 		if (ret == 0)
@@ -72,14 +77,15 @@ fd_write(int fd, const char *buf, size_t len)
 }
 
 int
-fd_read(int fd, char *buf, size_t len)
+fd_read(int fd, char *__counted_by(len) buf, size_t len)
 {
+	char *pos = buf;
 	size_t remain = len;
 
 	while (remain > 0) {
 		int ret;
 
-		ret = read(fd, buf, remain);
+		ret = read(fd, pos, remain);
 
 		if (ret < 0) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -94,7 +100,7 @@ fd_read(int fd, char *buf, size_t len)
 		}
 
 		remain -= ret;
-		buf += ret;
+		pos += ret;
 		TRACE("Reading from fd %d: Read %d bytes, %zu bytes remaining.", fd, ret, remain);
 
 		if (ret == 0)
@@ -105,7 +111,8 @@ fd_read(int fd, char *buf, size_t len)
 }
 
 ssize_t
-fd_read_blockwise(int fd, void *buf, size_t len, size_t block_size, size_t alignment)
+fd_read_blockwise(int fd, void *__sized_by(len) buf, size_t len, size_t block_size,
+		  size_t alignment)
 {
 	ASSERT(buf);
 	ASSERT(fd > 0);
@@ -119,12 +126,14 @@ fd_read_blockwise(int fd, void *buf, size_t len, size_t block_size, size_t align
 	size_t fragment_len = len % block_size;
 	size_t blocks_len = len - fragment_len;
 
-	if ((size_t)buf & (alignment - 1)) {
-		int r = posix_memalign(&p, alignment, len);
+	if ((uintptr_t)buf & (alignment - 1)) {
+		void *__unsafe_indexable raw_p = NULL;
+		int r = posix_memalign(&raw_p, alignment, len);
 		if (r) {
 			ERROR("posix_memalign returned %d", r);
 			return -1;
 		}
+		p = __unsafe_forge_bidi_indexable(void *, raw_p, len);
 	} else {
 		p = buf;
 	}
@@ -134,11 +143,13 @@ fd_read_blockwise(int fd, void *buf, size_t len, size_t block_size, size_t align
 	}
 
 	if (fragment_len) {
-		int r = posix_memalign(&fragment_buf, alignment, block_size);
+		void *__unsafe_indexable raw_frag = NULL;
+		int r = posix_memalign(&raw_frag, alignment, block_size);
 		if (r) {
 			ERROR("posix_memalign returned %d", r);
 			goto out;
 		}
+		fragment_buf = __unsafe_forge_bidi_indexable(void *, raw_frag, block_size);
 		if (fd_read(fd, fragment_buf, block_size) < (int)fragment_len) {
 			goto out;
 		}

--- a/common/fd.h
+++ b/common/fd.h
@@ -42,7 +42,7 @@
  * @param len length of the buffer
  */
 ssize_t
-fd_write(const int fd, const char *buf, ssize_t len);
+fd_write(const int fd, const char *buf, size_t len);
 
 /*
  * Reads the specified amount of bytes from the given file descriptor to the given buffer,

--- a/common/fd.h
+++ b/common/fd.h
@@ -31,7 +31,10 @@
 #ifndef FD_H
 #define FD_H
 
+#include "bounds_safety.h"
+
 #include <stddef.h>
+#include <sys/types.h>
 
 /**
  * Writes the given buffer of the given length to the given file descriptor,
@@ -42,7 +45,7 @@
  * @param len length of the buffer
  */
 ssize_t
-fd_write(const int fd, const char *buf, size_t len);
+fd_write(const int fd, const char *__counted_by(len) buf, size_t len);
 
 /*
  * Reads the specified amount of bytes from the given file descriptor to the given buffer,
@@ -53,7 +56,7 @@ fd_write(const int fd, const char *buf, size_t len);
  * @param number of bytes to read (must fit into given buffer!)
  */
 int
-fd_read(int fd, char *buf, size_t len);
+fd_read(int fd, char *__counted_by(len) buf, size_t len);
 
 /*
  * Reads blockwise from the given file descriptor to the given buffer, calling fd_read
@@ -68,7 +71,8 @@ fd_read(int fd, char *buf, size_t len);
  * @return number of bytes read on success, otherwise -1
  */
 ssize_t
-fd_read_blockwise(int fd, void *buf, size_t len, size_t block_size, size_t alignment);
+fd_read_blockwise(int fd, void *__sized_by(len) buf, size_t len, size_t block_size,
+		  size_t alignment);
 
 /**
  * Makes the given file descriptor non-blocking by setting the O_NONBLOCK flag.

--- a/common/file.bounds_test.c
+++ b/common/file.bounds_test.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file file.bounds_test.c
+ *
+ * Standalone bounds-safety enforcement tests for file.c.
+ *
+ * Must be compiled with the swiftlang Clang fork and -fbounds-safety.
+ * Uses fork() to test that out-of-bounds access traps at runtime.
+ * Dynamic (malloc'd) buffer sizes force runtime checks — the compiler
+ * cannot catch these statically.
+ *
+ * Build:
+ *   make bounds_test CC=/path/to/bs-clang
+ */
+
+#include "bounds_test.h"
+#include "file.h"
+#include "mem.h"
+
+#ifdef BOUNDS_SAFETY_ENABLED
+
+/* Prevent the compiler from constant-folding sizes. */
+static volatile size_t dynamic_4 = 4;
+static volatile size_t dynamic_16 = 16;
+
+/* Sink to prevent optimising away the call. */
+static volatile int sink;
+
+/*
+ * Each violation allocates a buffer of real size N, then calls a file
+ * function claiming size > N.  The runtime bounds check at the call
+ * site should trap.
+ */
+
+static void
+violate_file_write(void)
+{
+	char tmppath[] = "/tmp/file_bounds_test_XXXXXX";
+	int fd = mkstemp(tmppath);
+	if (fd < 0)
+		_exit(2);
+	close(fd);
+
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	memcpy(buf, "test", 4);
+	/* buf has 4 bytes, but we claim len=16 → trap */
+	sink = file_write(__unsafe_null_terminated_from_indexable(tmppath), buf, dynamic_16);
+
+	unlink(tmppath);
+}
+
+static void
+violate_file_read(void)
+{
+	/* Create a temp file with some content. */
+	char tmppath[] = "/tmp/file_bounds_test_XXXXXX";
+	int fd = mkstemp(tmppath);
+	if (fd < 0)
+		_exit(2);
+	write(fd, "0123456789abcdef", 16);
+	close(fd);
+
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	/* buf has 4 bytes, but we claim len=16 → trap */
+	sink = file_read(__unsafe_null_terminated_from_indexable(tmppath), buf, dynamic_16);
+
+	unlink(tmppath);
+}
+
+static struct bounds_test_case cases[] = { { "file_write OOB buf", violate_file_write },
+					   { "file_read OOB buf", violate_file_read },
+					   { NULL, NULL } };
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+BOUNDS_TEST_MAIN("file.bounds_test", cases)

--- a/common/file.c
+++ b/common/file.c
@@ -258,7 +258,7 @@ file_move(const char *src, const char *dst, size_t bs)
 }
 
 static int
-file_write_internal(const char *file, const char *buf, ssize_t len, int oflags)
+file_write_internal(const char *file, const char *buf, size_t len, int oflags)
 {
 	int fd;
 
@@ -270,9 +270,6 @@ file_write_internal(const char *file, const char *buf, ssize_t len, int oflags)
 		DEBUG_ERRNO("Could not open output file %s", file);
 		return -1;
 	}
-
-	if (len < 0)
-		len = strlen(buf);
 
 	int bytes_written = fd_write(fd, buf, len);
 	if (bytes_written < 0) {
@@ -290,13 +287,13 @@ file_write_internal(const char *file, const char *buf, ssize_t len, int oflags)
 }
 
 int
-file_write(const char *file, const char *buf, ssize_t len)
+file_write(const char *file, const char *buf, size_t len)
 {
 	return file_write_internal(file, buf, len, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW);
 }
 
 int
-file_write_append(const char *file, const char *buf, ssize_t len)
+file_write_append(const char *file, const char *buf, size_t len)
 {
 	int oflags = O_WRONLY | O_NOFOLLOW;
 	oflags |= file_exists(file) ? O_APPEND : (O_CREAT | O_TRUNC);
@@ -317,7 +314,7 @@ file_printf(const char *file, const char *fmt, ...)
 	buf = mem_vprintf(fmt, ap);
 	va_end(ap);
 
-	ret = file_write(file, buf, -1);
+	ret = file_write(file, buf, strlen(buf));
 	mem_free0(buf);
 	return ret;
 }
@@ -335,7 +332,7 @@ file_printf_append(const char *file, const char *fmt, ...)
 	buf = mem_vprintf(fmt, ap);
 	va_end(ap);
 
-	ret = file_write_append(file, buf, -1);
+	ret = file_write_append(file, buf, strlen(buf));
 	mem_free0(buf);
 	return ret;
 }
@@ -399,7 +396,7 @@ file_size(const char *file)
 	return s.st_size;
 }
 
-char *
+const char *
 file_get_extension(const char *file)
 {
 	ASSERT(file);

--- a/common/file.c
+++ b/common/file.c
@@ -28,6 +28,7 @@
 
 #include "file.h"
 
+#include "bounds_safety.h"
 #include "macro.h"
 #include "logf.h"
 #include "mem.h"
@@ -100,7 +101,7 @@ file_is_mountpoint(const char *file)
 {
 	bool ret;
 	struct stat s, s_parent;
-	char *parent = mem_printf("%s/..", file);
+	char *__null_terminated parent = mem_printf("%s/..", file);
 
 	ret = !lstat(file, &s);
 	ret &= !lstat(parent, &s_parent);
@@ -258,7 +259,7 @@ file_move(const char *src, const char *dst, size_t bs)
 }
 
 static int
-file_write_internal(const char *file, const char *buf, size_t len, int oflags)
+file_write_internal(const char *file, const char *__counted_by(len) buf, size_t len, int oflags)
 {
 	int fd;
 
@@ -287,13 +288,13 @@ file_write_internal(const char *file, const char *buf, size_t len, int oflags)
 }
 
 int
-file_write(const char *file, const char *buf, size_t len)
+file_write(const char *file, const char *__counted_by(len) buf, size_t len)
 {
 	return file_write_internal(file, buf, len, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW);
 }
 
 int
-file_write_append(const char *file, const char *buf, size_t len)
+file_write_append(const char *file, const char *__counted_by(len) buf, size_t len)
 {
 	int oflags = O_WRONLY | O_NOFOLLOW;
 	oflags |= file_exists(file) ? O_APPEND : (O_CREAT | O_TRUNC);
@@ -305,7 +306,7 @@ int
 file_printf(const char *file, const char *fmt, ...)
 {
 	va_list ap;
-	char *buf;
+	char *__null_terminated buf;
 	int ret;
 
 	IF_NULL_RETVAL(file, -1);
@@ -314,7 +315,8 @@ file_printf(const char *file, const char *fmt, ...)
 	buf = mem_vprintf(fmt, ap);
 	va_end(ap);
 
-	ret = file_write(file, buf, strlen(buf));
+	size_t len = strlen(buf);
+	ret = file_write(file, __unsafe_forge_bidi_indexable(const char *, buf, len), len);
 	mem_free0(buf);
 	return ret;
 }
@@ -323,7 +325,7 @@ int
 file_printf_append(const char *file, const char *fmt, ...)
 {
 	va_list ap;
-	char *buf;
+	char *__null_terminated buf;
 	int ret;
 
 	IF_NULL_RETVAL(file, -1);
@@ -332,13 +334,14 @@ file_printf_append(const char *file, const char *fmt, ...)
 	buf = mem_vprintf(fmt, ap);
 	va_end(ap);
 
-	ret = file_write_append(file, buf, strlen(buf));
+	size_t len = strlen(buf);
+	ret = file_write_append(file, __unsafe_forge_bidi_indexable(const char *, buf, len), len);
 	mem_free0(buf);
 	return ret;
 }
 
 int
-file_read(const char *file, char *buf, size_t len)
+file_read(const char *file, char *__counted_by(len) buf, size_t len)
 {
 	int fd;
 
@@ -363,10 +366,11 @@ file_read(const char *file, char *buf, size_t len)
 	return bytes_read;
 }
 
-char *
+char *__null_terminated
 file_read_new(const char *file, size_t maxlen)
 {
-	char *maxbuf, *buf;
+	char *maxbuf;
+	char *__null_terminated buf;
 
 	IF_NULL_RETVAL(file, NULL);
 
@@ -382,7 +386,7 @@ file_read_new(const char *file, size_t maxlen)
 	// Make sure the buffer returned is nul terminated
 	maxbuf[bytes_read] = '\0';
 
-	buf = mem_strdup(maxbuf);
+	buf = mem_strdup(__unsafe_null_terminated_from_indexable(maxbuf));
 	mem_free0(maxbuf);
 	return buf;
 }
@@ -401,10 +405,10 @@ file_get_extension(const char *file)
 {
 	ASSERT(file);
 
-	char *ext = strrchr(file, '.');
+	char *__unsafe_indexable ext = strrchr(file, '.');
 	if (!ext)
 		return "";
-	return ext;
+	return __unsafe_forge_null_terminated(const char *, ext);
 }
 
 int

--- a/common/file.h
+++ b/common/file.h
@@ -30,6 +30,8 @@
 #ifndef FILE_H
 #define FILE_H
 
+#include "bounds_safety.h"
+
 #include <stdbool.h>
 #include <sys/types.h>
 
@@ -90,7 +92,7 @@ file_move(const char *src, const char *dst, size_t bs);
  * @return -1 on error else the number of bytes written.
  */
 int
-file_write(const char *file, const char *buf, size_t len);
+file_write(const char *file, const char *__counted_by(len) buf, size_t len);
 
 /**
  * Append  a string to the end of a file.
@@ -100,7 +102,7 @@ file_write(const char *file, const char *buf, size_t len);
  * @return -1 on error else the number of bytes written.
  */
 int
-file_write_append(const char *file, const char *buf, size_t len);
+file_write_append(const char *file, const char *__counted_by(len) buf, size_t len);
 
 /**
  * Write a string to a file using printf.
@@ -128,7 +130,7 @@ file_printf_append(const char *file, const char *fmt, ...);
  * @return -1 on error else the number of bytes read.
  */
 int
-file_read(const char *file, char *buf, size_t len);
+file_read(const char *file, char *__counted_by(len) buf, size_t len);
 
 /**
  * Read a string from a file and allocate memory for it.
@@ -136,7 +138,7 @@ file_read(const char *file, char *buf, size_t len);
  * @param maxlen The maximum length to read.
  * @return A newly allocated buffer with the string read from file and NULL in case of an error.
  */
-char *
+char *__null_terminated
 file_read_new(const char *file, size_t maxlen);
 
 /**

--- a/common/file.h
+++ b/common/file.h
@@ -86,21 +86,21 @@ file_move(const char *src, const char *dst, size_t bs);
  * Write a string to a file.
  * @param file The file name.
  * @param buf The buffer to be written.
- * @param len The length of buffer, maybe -1 to determine buffer length with strlen().
+ * @param len The length of buffer.
  * @return -1 on error else the number of bytes written.
  */
 int
-file_write(const char *file, const char *buf, ssize_t len);
+file_write(const char *file, const char *buf, size_t len);
 
 /**
  * Append  a string to the end of a file.
  * @param file The file name.
  * @param buf The buffer to be written.
- * @param len The length of buffer, maybe -1 to determine buffer length with strlen().
+ * @param len The length of buffer.
  * @return -1 on error else the number of bytes written.
  */
 int
-file_write_append(const char *file, const char *buf, ssize_t len);
+file_write_append(const char *file, const char *buf, size_t len);
 
 /**
  * Write a string to a file using printf.
@@ -152,7 +152,7 @@ file_size(const char *file);
  * Note: fails if path contains a '.' and file has no ending
  * @ param file The file name
  */
-char *
+const char *
 file_get_extension(const char *file);
 
 /**

--- a/common/hex.bounds_test.c
+++ b/common/hex.bounds_test.c
@@ -1,0 +1,122 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file hex.bounds_test.c
+ *
+ * Standalone bounds-safety enforcement tests for hex.c.
+ *
+ * Must be compiled with the swiftlang Clang fork and -fbounds-safety.
+ * Uses fork() to test that out-of-bounds access traps at runtime.
+ * Dynamic (malloc'd) buffer sizes force runtime checks — the compiler
+ * cannot catch these statically.
+ *
+ * Build:
+ *   $BS_CLANG $CFLAGS -fbounds-safety -c hex.bounds_test.c
+ *   $BS_CLANG -o hex.bounds_test hex.bounds_test.o hex.o mem.o logf.o ...
+ *   ./hex.bounds_test
+ */
+
+#include "bounds_test.h"
+#include "hex.h"
+#include "mem.h"
+
+#ifdef BOUNDS_SAFETY_ENABLED
+
+/* Prevent the compiler from constant-folding sizes. */
+static volatile size_t dynamic_2 = 2;
+static volatile size_t dynamic_4 = 4;
+
+/* Sink to prevent optimising away the call. */
+static volatile int sink;
+
+/*
+ * Each violation allocates a buffer of real size N, forges bounds of size N,
+ * then calls a hex function claiming size > N.  The runtime bounds check at
+ * the call site should trap.
+ */
+
+static void
+violate_hex_to_bin_output(void)
+{
+	size_t real = dynamic_2;
+	uint8_t *out = (uint8_t *)mem_alloc0(real);
+	/* out has 2 bytes, but we claim outlen=4 → trap */
+	sink = convert_hex_to_bin("deadbeef", 8, out, dynamic_4);
+}
+
+static void
+violate_hex_to_bin_input(void)
+{
+	size_t real = dynamic_4;
+	char *in = (char *)mem_alloc0(real);
+	memcpy(in, "dead", 4);
+	uint8_t *out = (uint8_t *)mem_alloc0(real);
+	/* in has 4 bytes, but we claim inlen=8 → trap */
+	sink = convert_hex_to_bin(in, 8, out, dynamic_4);
+}
+
+static void
+violate_bin_to_hex_output(void)
+{
+	uint8_t in_data[4] = { 0xde, 0xad, 0xbe, 0xef };
+	size_t real = dynamic_2;
+	uint8_t *out = (uint8_t *)mem_alloc0(real);
+	/* out has 2 bytes, but we claim outlen=9 → trap */
+	sink = convert_bin_to_hex(in_data, 4, out, 9);
+}
+
+static void
+violate_bin_to_hex_input(void)
+{
+	size_t real = dynamic_2;
+	uint8_t *in = (uint8_t *)mem_alloc0(real);
+	in[0] = 0xde;
+	in[1] = 0xad;
+	uint8_t *out = (uint8_t *)mem_alloc0(9);
+	/* in has 2 bytes, but we claim inlen=4 → trap */
+	sink = convert_bin_to_hex(in, dynamic_4, out, 9);
+}
+
+static void
+violate_bin_to_hex_new_input(void)
+{
+	size_t real = dynamic_2;
+	uint8_t *bin = (uint8_t *)mem_alloc0(real);
+	bin[0] = 0xde;
+	bin[1] = 0xad;
+	/* bin has 2 bytes, but we claim length=4 → trap */
+	sink = (intptr_t)convert_bin_to_hex_new(bin, dynamic_4);
+}
+
+static struct bounds_test_case cases[] = { { "hex_to_bin OOB output", violate_hex_to_bin_output },
+					   { "hex_to_bin OOB input", violate_hex_to_bin_input },
+					   { "bin_to_hex OOB output", violate_bin_to_hex_output },
+					   { "bin_to_hex OOB input", violate_bin_to_hex_input },
+					   { "bin_to_hex_new OOB input",
+					     violate_bin_to_hex_new_input },
+					   { NULL, NULL } };
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+BOUNDS_TEST_MAIN("hex.bounds_test", cases)

--- a/common/hex.c
+++ b/common/hex.c
@@ -24,11 +24,13 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include "bounds_safety.h"
 #include "macro.h"
 #include "mem.h"
 
 int
-convert_hex_to_bin(const char *in, size_t inlen, uint8_t *out, size_t outlen)
+convert_hex_to_bin(const char *__counted_by(inlen) in, size_t inlen,
+		   uint8_t *__counted_by(outlen) out, size_t outlen)
 {
 	ASSERT(inlen >= 2);
 
@@ -60,7 +62,8 @@ convert_hex_to_bin(const char *in, size_t inlen, uint8_t *out, size_t outlen)
 }
 
 int
-convert_bin_to_hex(const uint8_t *in, size_t inlen, uint8_t *out, size_t outlen)
+convert_bin_to_hex(const uint8_t *__counted_by(inlen) in, size_t inlen,
+		   uint8_t *__counted_by(outlen) out, size_t outlen)
 {
 	size_t len = MUL_WITH_OVERFLOW_CHECK(inlen, (size_t)2);
 	len = MUL_WITH_OVERFLOW_CHECK(len, sizeof(char));
@@ -78,7 +81,7 @@ convert_bin_to_hex(const uint8_t *in, size_t inlen, uint8_t *out, size_t outlen)
 }
 
 char *
-convert_bin_to_hex_new(const uint8_t *bin, size_t length)
+convert_bin_to_hex_new(const uint8_t *__counted_by(length) bin, size_t length)
 {
 	size_t len = MUL_WITH_OVERFLOW_CHECK(length, (size_t)2);
 	len = MUL_WITH_OVERFLOW_CHECK(len, sizeof(char));

--- a/common/hex.c
+++ b/common/hex.c
@@ -78,14 +78,14 @@ convert_bin_to_hex(const uint8_t *in, size_t inlen, uint8_t *out, size_t outlen)
 }
 
 char *
-convert_bin_to_hex_new(const uint8_t *bin, int length)
+convert_bin_to_hex_new(const uint8_t *bin, size_t length)
 {
 	size_t len = MUL_WITH_OVERFLOW_CHECK(length, (size_t)2);
 	len = MUL_WITH_OVERFLOW_CHECK(len, sizeof(char));
 	len = ADD_WITH_OVERFLOW_CHECK(len, 1);
 	char *hex = mem_alloc0(len);
 
-	for (int i = 0; i < length; ++i) {
+	for (size_t i = 0; i < length; ++i) {
 		// remember snprintf additionally writes a '0' byte
 		snprintf(hex + i * 2, 3, "%.2x", bin[i]);
 	}

--- a/common/hex.h
+++ b/common/hex.h
@@ -24,16 +24,20 @@
 #ifndef HEX_H_
 #define HEX_H_
 
+#include "bounds_safety.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
 int
-convert_hex_to_bin(const char *in, size_t inlen, uint8_t *out, size_t outlen);
+convert_hex_to_bin(const char *__counted_by(inlen) in, size_t inlen,
+		   uint8_t *__counted_by(outlen) out, size_t outlen);
 
 int
-convert_bin_to_hex(const uint8_t *in, size_t inlen, uint8_t *out, size_t outlen);
+convert_bin_to_hex(const uint8_t *__counted_by(inlen) in, size_t inlen,
+		   uint8_t *__counted_by(outlen) out, size_t outlen);
 
 char *
-convert_bin_to_hex_new(const uint8_t *bin, size_t length);
+convert_bin_to_hex_new(const uint8_t *__counted_by(length) bin, size_t length);
 
 #endif // HEX_H_

--- a/common/hex.h
+++ b/common/hex.h
@@ -24,6 +24,9 @@
 #ifndef HEX_H_
 #define HEX_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 int
 convert_hex_to_bin(const char *in, size_t inlen, uint8_t *out, size_t outlen);
 
@@ -31,6 +34,6 @@ int
 convert_bin_to_hex(const uint8_t *in, size_t inlen, uint8_t *out, size_t outlen);
 
 char *
-convert_bin_to_hex_new(const uint8_t *bin, int length);
+convert_bin_to_hex_new(const uint8_t *bin, size_t length);
 
 #endif // HEX_H_

--- a/common/mem.c
+++ b/common/mem.c
@@ -28,6 +28,7 @@
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
+#include "bounds_safety.h"
 #include "mem.h"
 #include "macro.h"
 
@@ -37,7 +38,7 @@
 			DEBUG("Allocating a large memory area of %zu bytes", size);                \
 	} while (0)
 
-void *
+void *__sized_by(size)
 mem_alloc(size_t size)
 {
 	DEBUG_THRESHOLD(size);
@@ -46,7 +47,7 @@ mem_alloc(size_t size)
 	return p;
 }
 
-void *
+void *__sized_by(size)
 mem_alloc0(size_t size)
 {
 	DEBUG_THRESHOLD(size);
@@ -55,7 +56,7 @@ mem_alloc0(size_t size)
 	return p;
 }
 
-void *
+void *__sized_by(size)
 mem_realloc(void *mem, size_t size)
 {
 	DEBUG_THRESHOLD(size);
@@ -64,27 +65,27 @@ mem_realloc(void *mem, size_t size)
 	return p;
 }
 
-char *
-mem_strdup(const char *str)
+char *__null_terminated
+mem_strdup(const char *__null_terminated str)
 {
 	ASSERT(str);
-	char *p = strdup(str);
+	char *__null_terminated p = __unsafe_forge_null_terminated(char *, strdup(str));
 	ASSERT(p);
 	return p;
 }
 
-char *
-mem_strndup(const char *str, size_t len)
+char *__null_terminated
+mem_strndup(const char *__counted_by(len) str, size_t len)
 {
 	ASSERT(str);
 	DEBUG_THRESHOLD(len);
-	char *p = strndup(str, len);
+	char *__null_terminated p = __unsafe_forge_null_terminated(char *, strndup(str, len));
 	ASSERT(p);
 	return p;
 }
 
-unsigned char *
-mem_memcpy(const unsigned char *mem, size_t size)
+unsigned char *__sized_by(size)
+mem_memcpy(const unsigned char *__sized_by(size) mem, size_t size)
 {
 	ASSERT(mem);
 	unsigned char *p = mem_alloc0(size);
@@ -93,25 +94,25 @@ mem_memcpy(const unsigned char *mem, size_t size)
 	return p;
 }
 
-char *
-mem_vprintf(const char *fmt, va_list ap)
+char *__null_terminated
+mem_vprintf(const char *__null_terminated fmt, va_list ap)
 {
-	char *p = NULL;
+	char *__unsafe_indexable p = NULL;
 	ASSERT(fmt);
 	ASSERT(vasprintf(&p, fmt, ap) >= 0);
-	return p;
+	return __unsafe_forge_null_terminated(char *, p);
 }
 
-char *
-mem_printf(const char *fmt, ...)
+char *__null_terminated
+mem_printf(const char *__null_terminated fmt, ...)
 {
-	char *p = NULL;
+	char *__unsafe_indexable p = NULL;
 	va_list ap;
 	ASSERT(fmt);
 	va_start(ap, fmt);
 	ASSERT(vasprintf(&p, fmt, ap) >= 0);
 	va_end(ap);
-	return p;
+	return __unsafe_forge_null_terminated(char *, p);
 }
 
 void
@@ -121,7 +122,7 @@ mem_free(void *ptr)
 }
 
 void
-mem_free_array(void **array, size_t size)
+mem_free_array(void *__single *__counted_by(size) array, size_t size)
 {
 	if (array != NULL) {
 		size_t i = 0;
@@ -135,6 +136,6 @@ mem_free_array(void **array, size_t size)
 		}
 
 		DEBUG("[MEM] Freeing array");
-		mem_free0(array);
+		mem_free(array);
 	}
 }

--- a/common/mem.h
+++ b/common/mem.h
@@ -32,6 +32,8 @@
 #ifndef MEM_H
 #define MEM_H
 
+#include "bounds_safety.h"
+
 #include <stddef.h>
 #include <stdarg.h>
 #include <string.h>
@@ -43,7 +45,7 @@
  * @param size The number of bytes to allocate.
  * @return Pointer to the allocated memory.
  */
-void *
+void *__sized_by(size)
 mem_alloc(size_t size);
 
 /**
@@ -53,7 +55,7 @@ mem_alloc(size_t size);
  * @param size The number of bytes to allocate.
  * @return Poiner to the allocated memory.
  */
-void *
+void *__sized_by(size)
 mem_alloc0(size_t size);
 
 /**
@@ -64,7 +66,7 @@ mem_alloc0(size_t size);
  * @param size The new size of the memory block.
  * @return Pointer to the newly allocated memory.
  */
-void *
+void *__sized_by(size)
 mem_realloc(void *mem, size_t size);
 
 /**
@@ -74,19 +76,24 @@ mem_realloc(void *mem, size_t size);
  * @param str The string to duplicate.
  * @return Pointer to the new string.
  */
-char *
-mem_strdup(const char *str);
+char *__null_terminated
+mem_strdup(const char *__null_terminated str);
 
 /**
  * Duplicates a string, but copies at most len bytes. Allocates sufficient memory.
  * This is a wrapper for strndup(3) which aborts if the duplication fails.
  *
+ * str must be readable for len bytes (it need not be null-terminated; copying
+ * stops at the first null or after len bytes, whichever comes first). Callers
+ * that only know str is a null-terminated string must pass a len that does not
+ * exceed its length.
+ *
  * @param str The string to duplicate.
  * @param len The maximum length of the new string.
  * @return Pointer to the new string.
  */
-char *
-mem_strndup(const char *str, size_t len);
+char *__null_terminated
+mem_strndup(const char *__counted_by(len) str, size_t len);
 
 /**
  * Duplicates an array of unsigned char, but copies at most size bytes.
@@ -97,8 +104,8 @@ mem_strndup(const char *str, size_t len);
  * @param size The size of the memory.
  * @return Pointer to the new array.
  */
-unsigned char *
-mem_memcpy(const unsigned char *mem, size_t size);
+unsigned char *__sized_by(size)
+mem_memcpy(const unsigned char *__sized_by(size) mem, size_t size);
 
 /**
  * Prints to a string allocated by this function.
@@ -108,8 +115,8 @@ mem_memcpy(const unsigned char *mem, size_t size);
  * @param ap va_list
  * @return Pointer to the allocated formatted string.
  */
-char *
-mem_vprintf(const char *fmt, va_list ap);
+char *__null_terminated
+mem_vprintf(const char *__null_terminated fmt, va_list ap);
 
 /**
  * Prints to a string allocated by this function.
@@ -118,8 +125,8 @@ mem_vprintf(const char *fmt, va_list ap);
  * @param fmt The format string.
  * @return Pointer to the allocated formatted string.
  */
-char *
-mem_printf(const char *fmt, ...)
+char *__null_terminated
+mem_printf(const char *__null_terminated fmt, ...)
 #if defined(__GNUC__)
 	__attribute__((format(printf, 1, 2)))
 #endif
@@ -149,7 +156,7 @@ mem_free(void *ptr);
  * @param size Array size.
  */
 void
-mem_free_array(void **array, size_t size);
+mem_free_array(void *__single *__counted_by(size) array, size_t size);
 
 /**
  * Convenience wrapper macro for mem_alloc which calculates
@@ -215,14 +222,14 @@ mem_free_array(void **array, size_t size);
 	})
 
 static inline void
-mem_memset0(void *ptr, size_t num)
+mem_memset0(void *__sized_by(num) ptr, size_t num)
 {
 	static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
 	memset_v(ptr, 0, num);
 }
 
 static inline void
-mem_memset(void *ptr, int value, size_t num)
+mem_memset(void *__sized_by(num) ptr, int value, size_t num)
 {
 	memset(ptr, value, num);
 }

--- a/common/mem.h
+++ b/common/mem.h
@@ -151,6 +151,21 @@ mem_free(void *ptr);
 #define mem_free0(ptr) ((void)(free(ptr), (ptr) = NULL))
 
 /**
+ * Frees a bounds-safe (__sized_by/__counted_by) pointer and clears both the
+ * pointer and its paired length/count together, preserving the invariant that
+ * -fbounds-safety enforces. Use for annotated struct fields where plain
+ * mem_free0() is rejected (it would null the pointer without updating the count).
+ * @param ptr Memory pointer to be freed and set to NULL.
+ * @param count Paired length/count to be set to 0.
+ */
+#define mem_free0_sized(ptr, count)                                                                \
+	do {                                                                                       \
+		free(ptr);                                                                         \
+		(ptr) = NULL;                                                                      \
+		(count) = 0;                                                                       \
+	} while (0)
+
+/**
  * Frees the allocated memory of each array element and the array itself.
  * @param array Array to be freed.
  * @param size Array size.

--- a/common/mem.test.c
+++ b/common/mem.test.c
@@ -150,8 +150,10 @@ test_strdup_strndup(UNUSED const MunitParameter params[], UNUSED void *data)
 	munit_assert_string_equal("hehe, s", c);
 	mem_free0(c);
 
-	// strndup does not overflow
-	c = mem_strndup(a, 1024);
+	// strndup stops at the null terminator even when len spans the whole buffer
+	char big[1024] = { 0 };
+	memcpy(big, a, strlen(a));
+	c = mem_strndup(big, sizeof(big));
 	munit_assert_not_null(c);
 	munit_assert_string_equal(a, c);
 	mem_free0(c);

--- a/common/proc.c
+++ b/common/proc.c
@@ -23,6 +23,7 @@
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
+#include "bounds_safety.h"
 #include "macro.h"
 #include "proc.h"
 #include "mem.h"
@@ -73,7 +74,9 @@ proc_status_t *
 proc_status_new(pid_t pid)
 {
 	proc_status_t *status;
-	char *file, *buf, *tmp;
+	char *__null_terminated file;
+	char *__null_terminated buf;
+	char *__unsafe_indexable tmp; /* interior pointer into buf from strstr */
 	int n;
 
 	file = mem_printf("/proc/%d/status", pid);
@@ -86,9 +89,14 @@ proc_status_new(pid_t pid)
 
 	n = sscanf(buf, "Name:\t%15c", status->name);
 	IF_FALSE_GOTO(n == 1, error);
-	tmp = strchr(status->name, '\n');
-	if (tmp)
-		tmp[0] = '\0';
+	/* %15c does not NUL-terminate; trailing bytes are 0 from mem_new0. Truncate
+	 * the name at the first newline by walking the fixed array (bounds-checked). */
+	for (char *p = status->name; *p; p++) {
+		if (*p == '\n') {
+			*p = '\0';
+			break;
+		}
+	}
 	TRACE("Parsed name for %d: %s", pid, status->name);
 
 	tmp = strstr(buf, "\nState:");
@@ -155,7 +163,8 @@ const char *
 proc_status_get_name(const proc_status_t *status)
 {
 	ASSERT(status);
-	return status->name;
+	/* name is a fixed char[16], always NUL-terminated (zeroed struct + %15c) */
+	return __unsafe_null_terminated_from_indexable(status->name);
 }
 
 pid_t
@@ -182,9 +191,9 @@ proc_status_get_cap_eff(const proc_status_t *status)
 static int
 proc_killall_cb(UNUSED const char *path, const char *file, void *data)
 {
-	struct proc_killall *pk = data;
+	struct proc_killall *__single pk = data;
 
-	char *tmp = NULL;
+	char *__unsafe_indexable tmp = NULL;
 	errno = 0;
 	long lpid = strtol(file, &tmp, 10);
 	if (!tmp || tmp[0] != '\0') // filename is not a number
@@ -204,7 +213,7 @@ proc_killall_cb(UNUSED const char *path, const char *file, void *data)
 	}
 
 	pid_t ppid = proc_status_get_ppid(status);
-	const char *name = proc_status_get_name(status);
+	const char *__null_terminated name = proc_status_get_name(status);
 
 	if ((pk->ppid < 0 || pk->ppid == ppid) && !strcmp(name, pk->name)) {
 		DEBUG("Killing process %s with pid %d", pk->name, pid);
@@ -233,9 +242,9 @@ proc_killall(pid_t ppid, const char *name, int sig)
 static int
 proc_find_cb(UNUSED const char *path, const char *file, void *data)
 {
-	struct proc_find *pf = data;
+	struct proc_find *__single pf = data;
 
-	char *tmp = NULL;
+	char *__unsafe_indexable tmp = NULL;
 	errno = 0;
 	long lpid = strtol(file, &tmp, 10);
 	if (!tmp || tmp[0] != '\0') // filename is not a number
@@ -248,7 +257,7 @@ proc_find_cb(UNUSED const char *path, const char *file, void *data)
 	IF_NULL_RETVAL_TRACE(status, 0);
 
 	pid_t ppid = proc_status_get_ppid(status);
-	const char *name = proc_status_get_name(status);
+	const char *__null_terminated name = proc_status_get_name(status);
 
 	if (pf->match < 0 && (pf->ppid == ppid) && !strcmp(name, pf->name)) {
 		TRACE("Found pid %d with ppid %d and name %s", pid, ppid, pf->name);
@@ -305,9 +314,9 @@ int
 proc_cap_last_cap(void)
 {
 	int cap = -1;
-	const char *file_cap_last_cap = "/proc/sys/kernel/cap_last_cap";
+	const char *__null_terminated file_cap_last_cap = "/proc/sys/kernel/cap_last_cap";
 
-	char *str_cap_last_cap = file_read_new(file_cap_last_cap, 24);
+	char *__null_terminated str_cap_last_cap = file_read_new(file_cap_last_cap, 24);
 	IF_NULL_RETVAL(str_cap_last_cap, -1);
 
 	if (sscanf(str_cap_last_cap, "%d", &cap) != 1 || cap < 0) {
@@ -322,10 +331,10 @@ proc_cap_last_cap(void)
 int
 proc_stat_btime(unsigned long long *boottime_sec)
 {
-	FILE *proc;
+	FILE *__single proc;
 	char line_buf[2048];
 
-	IF_NULL_RETVAL((proc = fopen("/proc/stat", "r")), -1);
+	IF_NULL_RETVAL((proc = __unsafe_forge_single(FILE *, fopen("/proc/stat", "r"))), -1);
 
 	while (fgets(line_buf, 2048, proc)) {
 		if (sscanf(line_buf, "btime %llu", boottime_sec) != 1)
@@ -343,17 +352,17 @@ proc_stat_btime(unsigned long long *boottime_sec)
 	return -1;
 }
 
-char *
+char *__null_terminated
 proc_get_cgroups_path_new(pid_t pid)
 {
 	char line_buf[2048];
-	FILE *proc = NULL;
-	char *cgroup_path = NULL;
+	FILE *__single proc = NULL;
+	char *__null_terminated cgroup_path = NULL;
 	bool read_one_line = false;
 
-	char *path = mem_printf("/proc/%d/cgroup", pid);
+	char *__null_terminated path = mem_printf("/proc/%d/cgroup", pid);
 
-	if (NULL == (proc = fopen(path, "r"))) {
+	if (NULL == (proc = __unsafe_forge_single(FILE *, fopen(path, "r")))) {
 		mem_free0(path);
 		return NULL;
 	}
@@ -367,9 +376,17 @@ proc_get_cgroups_path_new(pid_t pid)
 		read_one_line = true;
 
 		if (strlen(line_buf) > 3 && !strncmp(line_buf, "0::", 3)) {
-			cgroup_path = mem_strdup(line_buf + 3);
-			// fgets does not remove '\n'
-			cgroup_path[strcspn(cgroup_path, "\n")] = '\0';
+			/* line_buf is a fixed array, NUL-terminated by fgets and >3 chars */
+			cgroup_path =
+				mem_strdup(__unsafe_null_terminated_from_indexable(line_buf + 3));
+			// fgets does not remove '\n' -- truncate at it. Subscript on a
+			// __null_terminated pointer is not allowed, so walk it
+			for (char *__null_terminated p = cgroup_path; *p; p++) {
+				if (*p == '\n') {
+					*p = '\0';
+					break;
+				}
+			}
 			break;
 		}
 	}
@@ -389,7 +406,8 @@ proc_meminfo_t *
 proc_meminfo_new(void)
 {
 	proc_meminfo_t *meminfo;
-	char *buf, *tmp;
+	char *__null_terminated buf;
+	char *__unsafe_indexable tmp; /* points into buf via strstr */
 	int n;
 
 	buf = file_read_new("/proc/meminfo", 4096);
@@ -459,38 +477,46 @@ proc_waitpid(pid_t pid, int *status, int options)
 	return ret;
 }
 
-char *
+char *__null_terminated
 proc_get_filename_of_fd_new(pid_t pid, int fd)
 {
-	char *ret;
+	char *__null_terminated ret;
 
 	char *file_path = mem_alloc0(PATH_MAX);
-	char *path = mem_printf("/proc/%d/fd/%d", pid, fd);
+	char *__null_terminated path = mem_printf("/proc/%d/fd/%d", pid, fd);
 
 	ssize_t len = readlink(path, file_path, PATH_MAX);
 	if (len < 0 || len > PATH_MAX - 1)
 		ERROR_ERRNO("readlink on %s returned %zd", path, len);
 
-	ret = (len < 0 || len > PATH_MAX - 1) ? NULL : mem_strdup(file_path);
+	/* file_path is mem_alloc0'd (zeroed) and readlink wrote len < PATH_MAX bytes,
+	 * so it is NUL-terminated within bounds */
+	ret = (len < 0 || len > PATH_MAX - 1) ?
+		      NULL :
+		      mem_strdup(__unsafe_null_terminated_from_indexable(file_path));
 
 	mem_free0(file_path);
 	mem_free0(path);
 	return ret;
 }
 
-char *
+char *__null_terminated
 proc_get_cwd_new(pid_t pid)
 {
-	char *ret;
+	char *__null_terminated ret;
 
 	char *file_path = mem_alloc0(PATH_MAX);
-	char *path = mem_printf("/proc/%d/cwd", pid);
+	char *__null_terminated path = mem_printf("/proc/%d/cwd", pid);
 
 	ssize_t len = readlink(path, file_path, PATH_MAX);
 	if (len < 0 || len > PATH_MAX - 1)
 		ERROR_ERRNO("readlink on %s returned %zd", path, len);
 
-	ret = (len < 0 || len > PATH_MAX - 1) ? NULL : mem_strdup(file_path);
+	/* file_path is mem_alloc0'd (zeroed) and readlink wrote len < PATH_MAX bytes,
+	 * so it is NUL-terminated within bounds */
+	ret = (len < 0 || len > PATH_MAX - 1) ?
+		      NULL :
+		      mem_strdup(__unsafe_null_terminated_from_indexable(file_path));
 
 	mem_free0(file_path);
 	mem_free0(path);

--- a/common/proc.h
+++ b/common/proc.h
@@ -24,6 +24,8 @@
 #ifndef PROC_H
 #define PROC_H
 
+#include "bounds_safety.h"
+
 #include <unistd.h>
 #include <stdint.h>
 
@@ -90,7 +92,7 @@ proc_stat_btime(unsigned long long *boottime_sec);
  * @param pid The pid of the process to be checked
  * @return subfolder in mounted cgroup hirachy, "" on v1 systems, NULL on error
  */
-char *
+char *__null_terminated
 proc_get_cgroups_path_new(pid_t pid);
 
 typedef struct proc_meminfo proc_meminfo_t;
@@ -143,7 +145,7 @@ proc_waitpid(pid_t pid, int *status, int options);
  * @param fd The file descriptor
  * @return path of the file when fd was opened, NULL on error
  */
-char *
+char *__null_terminated
 proc_get_filename_of_fd_new(pid_t pid, int fd);
 
 /**
@@ -151,7 +153,7 @@ proc_get_filename_of_fd_new(pid_t pid, int fd);
  * @param pid The pid of the process
  * @return path of the cwd of the process with pid pid, NULL on error
  */
-char *
+char *__null_terminated
 proc_get_cwd_new(pid_t pid);
 
 #endif /* PROC_H */

--- a/common/protobuf-text.bounds_test.c
+++ b/common/protobuf-text.bounds_test.c
@@ -1,0 +1,80 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file protobuf-text.bounds_test.c
+ *
+ * Standalone bounds-safety enforcement tests for protobuf-text.c.
+ *
+ * Must be compiled with the swiftlang Clang fork and -fbounds-safety.
+ * Uses fork() to test that out-of-bounds access traps at runtime.
+ * Dynamic (malloc'd) buffer sizes force runtime checks — the compiler
+ * cannot catch these statically.
+ *
+ * Build:
+ *   make bounds_test CC=/path/to/bs-clang
+ */
+
+#include "bounds_test.h"
+#include "protobuf-text.h"
+#include "mem.h"
+
+#ifdef BOUNDS_SAFETY_ENABLED
+
+/* Prevent the compiler from constant-folding sizes. */
+static volatile size_t dynamic_4 = 4;
+static volatile size_t dynamic_16 = 16;
+
+/* Sink to prevent optimising away the call. Written-only on purpose (the
+ * volatile store is the side effect); marked unused for -Wunused-but-set-global
+ * under newer Clang. */
+static volatile void *sink __attribute__((unused));
+
+/*
+ * Each violation allocates a buffer of real size N, then calls a
+ * protobuf_text function claiming size > N.  The runtime bounds check
+ * at the call site should trap before the function body runs.
+ *
+ * We pass a bogus descriptor pointer since the trap fires before the
+ * function is entered.
+ */
+
+static void
+violate_protobuf_message_new_from_buf(void)
+{
+	size_t real = dynamic_4;
+	uint8_t *buf = (uint8_t *)mem_alloc0(real);
+	memset(buf, 'A', real);
+	/* buf has 4 bytes, but we claim buflen=16 -> trap */
+	sink = protobuf_message_new_from_buf(
+		buf, dynamic_16,
+		__unsafe_forge_single(const ProtobufCMessageDescriptor *, (void *)0x1));
+}
+
+static struct bounds_test_case cases[] = { { "protobuf_message_new_from_buf OOB buf",
+					     violate_protobuf_message_new_from_buf },
+					   { NULL, NULL } };
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+BOUNDS_TEST_MAIN("protobuf-text.bounds_test", cases)

--- a/common/protobuf-text.c
+++ b/common/protobuf-text.c
@@ -21,6 +21,7 @@
  * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
  */
 
+#include "bounds_safety.h"
 #include "protobuf.h"
 #include "protobuf-text.h"
 #include <errno.h>
@@ -43,7 +44,7 @@ protobuf_dump_message(int fd, const ProtobufCMessage *message)
 {
 	ASSERT(message);
 
-	char *string;
+	char *__null_terminated string;
 	size_t msg_len = protobuf_string_from_message(&string, message, NULL);
 	if (NULL == string) {
 		WARN("Failed to serialize text protobuf message to string.");
@@ -67,12 +68,13 @@ protobuf_message_new_from_textfile(const char *filename,
 
 	ProtobufCTextError res;
 	mem_memset(&res, 0, sizeof(res));
-	FILE *file = fopen(filename, "r");
+	FILE *__single file = __unsafe_forge_single(FILE *, fopen(filename, "r"));
 	if (!file) {
 		WARN_ERRNO("Could not open file \"%s\" for reading.", filename);
 		return NULL;
 	}
-	ProtobufCMessage *msg = protobuf_c_text_from_file(descriptor, file, &res, NULL);
+	ProtobufCMessage *__single msg = __unsafe_forge_single(
+		ProtobufCMessage *, protobuf_c_text_from_file(descriptor, file, &res, NULL));
 	fclose(file);
 	if (!msg) {
 		ERROR("Failed to parse text protobuf message (%s) from file \"%s\". Reason: %s.",
@@ -92,7 +94,7 @@ protobuf_message_new_from_textfile(const char *filename,
 }
 
 ProtobufCMessage *
-protobuf_message_new_from_string(char *string, const ProtobufCMessageDescriptor *descriptor)
+protobuf_message_new_from_string(const char *string, const ProtobufCMessageDescriptor *descriptor)
 {
 	ASSERT(string);
 	ASSERT(descriptor);
@@ -101,7 +103,9 @@ protobuf_message_new_from_string(char *string, const ProtobufCMessageDescriptor 
 
 	ProtobufCTextError res;
 	mem_memset(&res, 0, sizeof(res));
-	ProtobufCMessage *msg = protobuf_c_text_from_string(descriptor, string, &res, NULL);
+	ProtobufCMessage *__single msg = __unsafe_forge_single(
+		ProtobufCMessage *,
+		protobuf_c_text_from_string(descriptor, (char *)string, &res, NULL));
 	if (!msg) {
 		ERROR("Failed to parse text protobuf message (%s) from string. Reason: %s.",
 		      descriptor->name ? descriptor->name : "UNKNOWN",
@@ -124,7 +128,7 @@ protobuf_message_new_from_string(char *string, const ProtobufCMessageDescriptor 
 }
 
 ProtobufCMessage *
-protobuf_message_new_from_buf(const uint8_t *buf, size_t buflen,
+protobuf_message_new_from_buf(const uint8_t *__counted_by(buflen) buf, size_t buflen,
 			      const ProtobufCMessageDescriptor *descriptor)
 {
 	ASSERT(buf);
@@ -136,7 +140,8 @@ protobuf_message_new_from_buf(const uint8_t *buf, size_t buflen,
 	memcpy(string, buf, buflen);
 	string[buflen] = '\0';
 
-	ProtobufCMessage *msg = protobuf_message_new_from_string(string, descriptor);
+	ProtobufCMessage *msg = protobuf_message_new_from_string(
+		__unsafe_null_terminated_from_indexable(string), descriptor);
 
 	mem_free0(string);
 	return msg;
@@ -148,14 +153,14 @@ protobuf_message_write_to_file(const char *filename, const ProtobufCMessage *mes
 	ASSERT(filename);
 	ASSERT(message);
 
-	char *string;
+	char *__null_terminated string;
 	size_t msg_len = protobuf_string_from_message(&string, message, NULL);
 	if (!string) {
 		ERROR("Failed to serialize text protobuf message to string.");
 		return -1;
 	}
 
-	int res = file_write(filename, string, msg_len);
+	int res = file_write(filename, __null_terminated_to_indexable(string), msg_len);
 	free(string);
 	if (res < 0) {
 		ERROR("Failed to write serialized text protobuf message to file \"%s\".", filename);
@@ -165,13 +170,14 @@ protobuf_message_write_to_file(const char *filename, const ProtobufCMessage *mes
 }
 
 size_t
-protobuf_string_from_message(char **buffer_proto_string, const ProtobufCMessage *message,
-			     ProtobufCAllocator *allocator)
+protobuf_string_from_message(char *__null_terminated *buffer_proto_string,
+			     const ProtobufCMessage *message, ProtobufCAllocator *allocator)
 {
 	ASSERT(message);
 	size_t proto_len = -1;
 
-	char *tmp_string = protobuf_c_text_to_string(message, allocator);
+	char *__null_terminated tmp_string = __unsafe_forge_null_terminated(
+		char *, protobuf_c_text_to_string(message, allocator));
 	if (!tmp_string) {
 		ERROR("Failed to serialize text protobuf message to string.");
 		goto error;

--- a/common/protobuf-text.h
+++ b/common/protobuf-text.h
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+#include "bounds_safety.h"
 #include "protobuf.h"
 
 /**
@@ -73,10 +74,10 @@ protobuf_message_new_from_textfile(const char *filename,
  *          must be released with protobuf_free_message()
  */
 ProtobufCMessage *
-protobuf_message_new_from_string(char *string, const ProtobufCMessageDescriptor *descriptor);
+protobuf_message_new_from_string(const char *string, const ProtobufCMessageDescriptor *descriptor);
 
 ProtobufCMessage *
-protobuf_message_new_from_buf(const uint8_t *buf, size_t buflen,
+protobuf_message_new_from_buf(const uint8_t *__counted_by(buflen) buf, size_t buflen,
 			      const ProtobufCMessageDescriptor *descriptor);
 
 /**
@@ -96,7 +97,7 @@ protobuf_message_write_to_file(const char *filename, const ProtobufCMessage *mes
  * @param allocator protobuf C allocator
 */
 size_t
-protobuf_string_from_message(char **buffer_proto_string, const ProtobufCMessage *message,
-			     ProtobufCAllocator *allocator);
+protobuf_string_from_message(char *__null_terminated *buffer_proto_string,
+			     const ProtobufCMessage *message, ProtobufCAllocator *allocator);
 
 #endif // PROTOBUF_TEXT_H

--- a/common/protobuf.bounds_test.c
+++ b/common/protobuf.bounds_test.c
@@ -1,0 +1,92 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file protobuf.bounds_test.c
+ *
+ * Standalone bounds-safety enforcement tests for protobuf.c.
+ *
+ * Must be compiled with the swiftlang Clang fork and -fbounds-safety.
+ * Uses fork() to test that out-of-bounds access traps at runtime.
+ * Dynamic (malloc'd) buffer sizes force runtime checks — the compiler
+ * cannot catch these statically.
+ *
+ * Build:
+ *   make bounds_test CC=/path/to/bs-clang
+ */
+
+#include "bounds_test.h"
+#include "protobuf.h"
+#include "mem.h"
+
+#ifdef BOUNDS_SAFETY_ENABLED
+
+/* Prevent the compiler from constant-folding sizes. */
+static volatile size_t dynamic_4 = 4;
+static volatile uint32_t dynamic_buflen_16 = 16;
+
+/* Sink to prevent optimising away the call. */
+static volatile int sink;
+
+/*
+ * Each violation allocates a buffer of real size N, then calls a protobuf
+ * function claiming size > N.  The runtime bounds check at the call
+ * site should trap.
+ */
+
+static void
+violate_protobuf_send_message_packed(void)
+{
+	int pipefd[2];
+	if (pipe(pipefd) < 0)
+		_exit(2);
+
+	size_t real = dynamic_4;
+	uint8_t *buf = (uint8_t *)mem_alloc0(real);
+	memset(buf, 0xAA, real);
+	/* buf has 4 bytes, but we claim buflen=16 -> trap */
+	sink = (int)protobuf_send_message_packed(pipefd[1], buf, dynamic_buflen_16);
+
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+static void
+violate_protobuf_unpack_message(void)
+{
+	size_t real = dynamic_4;
+	uint8_t *buf = (uint8_t *)mem_alloc0(real);
+	ProtobufCMessageDescriptor desc = { 0 };
+	/* buf has 4 bytes, but we claim buf_len=16 -> trap */
+	sink = (intptr_t)protobuf_unpack_message(&desc, buf, dynamic_buflen_16);
+}
+
+static struct bounds_test_case cases[] = {
+	{ "protobuf_send_message_packed OOB buf", violate_protobuf_send_message_packed },
+	{ "protobuf_unpack_message OOB buf", violate_protobuf_unpack_message },
+	{ NULL, NULL }
+};
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+BOUNDS_TEST_MAIN("protobuf.bounds_test", cases)

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -24,6 +24,8 @@
 #include "protobuf.h"
 #include <errno.h>
 
+#include "bounds_safety.h"
+
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 #include "macro.h"
 #include "mem.h"
@@ -52,7 +54,7 @@ protobuf_pack_message_new(const ProtobufCMessage *message)
 }
 
 ssize_t
-protobuf_send_message_packed(int fd, const uint8_t *buf, uint32_t buflen)
+protobuf_send_message_packed(int fd, const uint8_t *__counted_by(buflen) buf, uint32_t buflen)
 {
 	ASSERT(buf);
 
@@ -94,8 +96,11 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 
 	if (!(packed.len < PROTOBUF_MAX_MESSAGE_SIZE)) {
 		ERROR("Packed message exceeds PROTOBUF_MAX_MESSAGE_SIZE");
-		if (packed.buf)
-			mem_free0(packed.buf);
+		if (packed.buf) {
+			free(packed.buf);
+			packed.buf = NULL;
+			packed.len = 0;
+		}
 
 		return -1;
 	}
@@ -103,14 +108,19 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 	TRACE("Sending protobuf message with len %u", packed.len);
 	TRACE_HEXDUMP(packed.buf, packed.len, "Message");
 
+	ssize_t ret = packed.len;
+
 	if (-1 == protobuf_send_message_packed(fd, packed.buf, packed.len)) {
 		ERROR_ERRNO("Failed to write packed protobuf message to fd %d.", fd);
-		mem_free0(packed.buf);
+		free(packed.buf);
+		packed.buf = NULL;
+		packed.len = 0;
 		return -1;
 	}
 
-	ssize_t ret = packed.len;
-	mem_free0(packed.buf);
+	free(packed.buf);
+	packed.buf = NULL;
+	packed.len = 0;
 
 	return ret;
 }
@@ -196,7 +206,8 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 	if (0 == buflen) {
 		TRACE("Got zero length message, returning default message fields");
 
-		return protobuf_c_message_unpack(descriptor, NULL, 0, NULL);
+		return __unsafe_forge_single(ProtobufCMessage *,
+				protobuf_c_message_unpack(descriptor, NULL, 0, NULL));
 	}
 
 	// -2 means that client closed connection
@@ -209,7 +220,8 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 		return NULL;
 	}
 
-	ProtobufCMessage *msg = protobuf_c_message_unpack(descriptor, NULL, buflen, buf);
+	ProtobufCMessage *msg = __unsafe_forge_single(ProtobufCMessage *,
+			protobuf_c_message_unpack(descriptor, NULL, buflen, buf));
 
 	if (!msg) {
 		WARN("Failed to parse received protobuf message");
@@ -223,12 +235,13 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 }
 
 ProtobufCMessage *
-protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor, uint8_t *buf,
-			uint32_t buf_len)
+protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor,
+			uint8_t *__counted_by(buf_len) buf, uint32_t buf_len)
 {
 	ASSERT(descriptor);
 
-	ProtobufCMessage *msg = protobuf_c_message_unpack(descriptor, NULL, buf_len, buf);
+	ProtobufCMessage *msg = __unsafe_forge_single(ProtobufCMessage *,
+			protobuf_c_message_unpack(descriptor, NULL, buf_len, buf));
 
 	return msg;
 }

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -57,9 +57,7 @@ void
 protobuf_pack_message_free(protobuf_packed_msg_t *msg)
 {
 	IF_NULL_RETURN(msg);
-	free(msg->buf);
-	msg->buf = NULL;
-	msg->len = 0;
+	mem_free0_sized(msg->buf, msg->len);
 }
 
 ssize_t
@@ -206,7 +204,7 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 		TRACE("Got zero length message, returning default message fields");
 
 		return __unsafe_forge_single(ProtobufCMessage *,
-				protobuf_c_message_unpack(descriptor, NULL, 0, NULL));
+					     protobuf_c_message_unpack(descriptor, NULL, 0, NULL));
 	}
 
 	// -2 means that client closed connection
@@ -219,8 +217,8 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 		return NULL;
 	}
 
-	ProtobufCMessage *msg = __unsafe_forge_single(ProtobufCMessage *,
-			protobuf_c_message_unpack(descriptor, NULL, buflen, buf));
+	ProtobufCMessage *msg = __unsafe_forge_single(
+		ProtobufCMessage *, protobuf_c_message_unpack(descriptor, NULL, buflen, buf));
 
 	if (!msg) {
 		WARN("Failed to parse received protobuf message");
@@ -239,8 +237,8 @@ protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor,
 {
 	ASSERT(descriptor);
 
-	ProtobufCMessage *msg = __unsafe_forge_single(ProtobufCMessage *,
-			protobuf_c_message_unpack(descriptor, NULL, buf_len, buf));
+	ProtobufCMessage *msg = __unsafe_forge_single(
+		ProtobufCMessage *, protobuf_c_message_unpack(descriptor, NULL, buf_len, buf));
 
 	return msg;
 }

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -53,6 +53,15 @@ protobuf_pack_message_new(const ProtobufCMessage *message)
 	return (protobuf_packed_msg_t){ .buf = packed, .len = actual_len };
 }
 
+void
+protobuf_pack_message_free(protobuf_packed_msg_t *msg)
+{
+	IF_NULL_RETURN(msg);
+	free(msg->buf);
+	msg->buf = NULL;
+	msg->len = 0;
+}
+
 ssize_t
 protobuf_send_message_packed(int fd, const uint8_t *__counted_by(buflen) buf, uint32_t buflen)
 {
@@ -96,12 +105,7 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 
 	if (!(packed.len < PROTOBUF_MAX_MESSAGE_SIZE)) {
 		ERROR("Packed message exceeds PROTOBUF_MAX_MESSAGE_SIZE");
-		if (packed.buf) {
-			free(packed.buf);
-			packed.buf = NULL;
-			packed.len = 0;
-		}
-
+		protobuf_pack_message_free(&packed);
 		return -1;
 	}
 
@@ -112,16 +116,11 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 
 	if (-1 == protobuf_send_message_packed(fd, packed.buf, packed.len)) {
 		ERROR_ERRNO("Failed to write packed protobuf message to fd %d.", fd);
-		free(packed.buf);
-		packed.buf = NULL;
-		packed.len = 0;
+		protobuf_pack_message_free(&packed);
 		return -1;
 	}
 
-	free(packed.buf);
-	packed.buf = NULL;
-	packed.len = 0;
-
+	protobuf_pack_message_free(&packed);
 	return ret;
 }
 

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -35,11 +35,10 @@
 
 // TODO update naming scheme
 
-uint32_t
-protobuf_pack_message_new(const ProtobufCMessage *message, uint8_t **ptr)
+protobuf_packed_msg_t
+protobuf_pack_message_new(const ProtobufCMessage *message)
 {
 	ASSERT(message);
-	ASSERT(ptr);
 
 	uint32_t packed_len = protobuf_c_message_get_packed_size(message);
 	uint8_t *packed = mem_alloc(packed_len);
@@ -49,9 +48,7 @@ protobuf_pack_message_new(const ProtobufCMessage *message, uint8_t **ptr)
 	uint32_t actual_len = protobuf_c_message_pack(message, packed);
 	ASSERT(actual_len == packed_len);
 
-	*ptr = packed;
-
-	return actual_len;
+	return (protobuf_packed_msg_t){ .buf = packed, .len = actual_len };
 }
 
 ssize_t
@@ -93,29 +90,29 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 {
 	ASSERT(message);
 
-	uint8_t *buf = NULL;
-	uint32_t buflen = protobuf_pack_message_new(message, &buf);
+	protobuf_packed_msg_t packed = protobuf_pack_message_new(message);
 
-	if (!(buflen < PROTOBUF_MAX_MESSAGE_SIZE)) {
+	if (!(packed.len < PROTOBUF_MAX_MESSAGE_SIZE)) {
 		ERROR("Packed message exceeds PROTOBUF_MAX_MESSAGE_SIZE");
-		if (buf)
-			mem_free0(buf);
+		if (packed.buf)
+			mem_free0(packed.buf);
 
 		return -1;
 	}
 
-	TRACE("Sending protobuf message with len %u", buflen);
-	TRACE_HEXDUMP(buf, buflen, "Message");
+	TRACE("Sending protobuf message with len %u", packed.len);
+	TRACE_HEXDUMP(packed.buf, packed.len, "Message");
 
-	if (-1 == protobuf_send_message_packed(fd, buf, buflen)) {
+	if (-1 == protobuf_send_message_packed(fd, packed.buf, packed.len)) {
 		ERROR_ERRNO("Failed to write packed protobuf message to fd %d.", fd);
-		mem_free0(buf);
+		mem_free0(packed.buf);
 		return -1;
 	}
 
-	mem_free0(buf);
+	ssize_t ret = packed.len;
+	mem_free0(packed.buf);
 
-	return buflen;
+	return ret;
 }
 
 uint8_t *

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -37,16 +37,18 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+#include "bounds_safety.h"
+
 // The protobuf default byte size limit is 64MB
 #define PROTOBUF_MAX_MESSAGE_SIZE 1024 * 1024 * 64
 #define PROTOBUF_MAX_OVERHEAD 1024
 
 /**
- * Packed protobuf message with paired buffer and length.
+ * Packed protobuf message with bounds-safe buffer.
  * Returned by protobuf_pack_message_new(); the caller must free buf.
  */
 typedef struct {
-	uint8_t *buf;
+	uint8_t *__sized_by(len) buf;
 	uint32_t len;
 } protobuf_packed_msg_t;
 
@@ -71,7 +73,7 @@ protobuf_pack_message_new(const ProtobufCMessage *message);
  * @return          the length of the given message (without length prefix)
  */
 ssize_t
-protobuf_send_message_packed(int fd, const uint8_t *buf, uint32_t buflen);
+protobuf_send_message_packed(int fd, const uint8_t *__counted_by(buflen) buf, uint32_t buflen);
 
 /**
  * Writes the given protobuf message struct to the given file descriptor
@@ -123,8 +125,8 @@ protobuf_recv_message_packed_new(int fd, ssize_t *msg_len);
  * @return the unpacked protobuf message message message to free
  */
 ProtobufCMessage *
-protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor, uint8_t *buf,
-			uint32_t buf_len);
+protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor,
+			uint8_t *__counted_by(buf_len) buf, uint32_t buf_len);
 
 /**
  * Frees an unpacked protobuf message struct (e.g. created by protobuf_recv_message()).

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -45,7 +45,7 @@
 
 /**
  * Packed protobuf message with bounds-safe buffer.
- * Returned by protobuf_pack_message_new(); the caller must free buf.
+ * Returned by protobuf_pack_message_new(); free with protobuf_pack_message_free().
  */
 typedef struct {
 	uint8_t *__sized_by(len) buf;
@@ -61,6 +61,14 @@ typedef struct {
  */
 protobuf_packed_msg_t
 protobuf_pack_message_new(const ProtobufCMessage *message);
+
+/**
+ * Frees the buffer inside a packed message and zeros both fields.
+ *
+ * @param msg   pointer to the packed message struct (may be NULL)
+ */
+void
+protobuf_pack_message_free(protobuf_packed_msg_t *msg);
 
 /**
  * Writes the given, serialized protobuf message struct to the given file descriptor

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -42,17 +42,23 @@
 #define PROTOBUF_MAX_OVERHEAD 1024
 
 /**
+ * Packed protobuf message with paired buffer and length.
+ * Returned by protobuf_pack_message_new(); the caller must free buf.
+ */
+typedef struct {
+	uint8_t *buf;
+	uint32_t len;
+} protobuf_packed_msg_t;
+
+/**
  * Packs the given protobuf message struct
  * and returns it's binary serialized form.
  *
- * The serialized message is prefixed with the length of the actual data.
- *
  * @param message   the protobuf message struct to serialize and write
- * @param ptr       the location to store a pointer to the serialized representation
- * @return          the length of the serialized message (without length prefix) or -1 on error
+ * @return          packed message with buffer and length; buf is NULL on error
  */
-uint32_t
-protobuf_pack_message_new(const ProtobufCMessage *message, uint8_t **ptr);
+protobuf_packed_msg_t
+protobuf_pack_message_new(const ProtobufCMessage *message);
 
 /**
  * Writes the given, serialized protobuf message struct to the given file descriptor

--- a/common/sock.c
+++ b/common/sock.c
@@ -27,6 +27,7 @@
 
 #include "macro.h"
 #include "mem.h"
+#include "bounds_safety.h"
 
 #include <ctype.h>
 #include <unistd.h>
@@ -242,7 +243,7 @@ sock_inet_connect_addrinfo(struct addrinfo *addrinfo)
 int
 sock_inet_create_and_connect(int type, const char *node, const char *service)
 {
-	struct addrinfo hints, *res = NULL;
+	struct addrinfo hints, *__single res = NULL;
 	int sock = -1;
 
 	mem_memset(&hints, 0, sizeof hints);
@@ -267,7 +268,7 @@ sock_inet_create_and_connect(int type, const char *node, const char *service)
 		if (sock != -1) {
 			break;
 		}
-		cur = cur->ai_next;
+		cur = __unsafe_forge_single(struct addrinfo *, cur->ai_next);
 	}
 
 out:
@@ -307,26 +308,28 @@ sock_unix_get_peer_pid(int sock, uint32_t *peer_pid)
 	return 0;
 }
 
-static char *
+static char *__null_terminated
 sock_get_env_var_name_new(const char *sock_name)
 {
 	// sock name: "cml-control" -> env var name: "CML_CONTROL"
 
-	char *env_var = mem_strdup(sock_name);
-	for (size_t i = 0; i < strlen(sock_name); i++)
-		env_var[i] = (sock_name[i] == '-') ? '_' : toupper(sock_name[i]);
+	char *__null_terminated env_var = mem_strdup(sock_name);
+	char *__null_terminated dst = env_var;
+	const char *__null_terminated src = sock_name;
+	for (; *src; src++, dst++)
+		*dst = (*src == '-') ? '_' : toupper(*src);
 
 	return env_var;
 }
 
-char *
+char *__null_terminated
 sock_get_path_new(const char *sock_name)
 {
-	char *sock_path = NULL;
-	char *env_var = sock_get_env_var_name_new(sock_name);
+	char *__null_terminated sock_path = NULL;
+	char *__null_terminated env_var = sock_get_env_var_name_new(sock_name);
 	IF_NULL_GOTO(env_var, out);
 
-	char *env_path = getenv(env_var);
+	char *__null_terminated env_path = __unsafe_forge_null_terminated(char *, getenv(env_var));
 	if (NULL == env_path) {
 		mem_free0(env_var);
 		goto out;

--- a/common/sock.h
+++ b/common/sock.h
@@ -36,6 +36,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include "bounds_safety.h"
+
 #ifdef ANDROID
 #include <cutils/sockets.h>
 #endif
@@ -242,7 +244,7 @@ sock_unix_get_peer_pid(int sock, uint32_t *peer_pid);
  * @param sock_name     The name of the socket
  * @return              The path of the socket 
 */
-char *
+char *__null_terminated
 sock_get_path_new(const char *sock_name);
 
 #endif // SOCK_H

--- a/common/str.bounds_test.c
+++ b/common/str.bounds_test.c
@@ -1,0 +1,124 @@
+/*
+ * This file is part of GyroidOS
+ * Copyright(c) 2013 - 2026 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <gyroidos@aisec.fraunhofer.de>
+ */
+
+/**
+ * @file str.bounds_test.c
+ *
+ * Standalone bounds-safety enforcement tests for str.c.
+ *
+ * Must be compiled with the swiftlang Clang fork and -fbounds-safety.
+ * Uses fork() to test that out-of-bounds access traps at runtime.
+ * Dynamic (malloc'd) buffer sizes force runtime checks — the compiler
+ * cannot catch these statically.
+ *
+ * Build:
+ *   make bounds_test CC=/path/to/bs-clang
+ */
+
+#include "bounds_test.h"
+#include "str.h"
+#include "mem.h"
+
+#ifdef BOUNDS_SAFETY_ENABLED
+
+/*
+ * str_t is an opaque (incomplete) type here.  Upstream -fbounds-safety defaults
+ * local pointers to __bidi_indexable, which requires a known pointee size.
+ * Use __single explicitly to stay compatible with both upstream and our local
+ * compiler patch that infers __single automatically for incomplete types.
+ */
+#define STR_LOCAL __single
+
+/* Prevent the compiler from constant-folding sizes. */
+static volatile size_t dynamic_4 = 4;
+static volatile size_t dynamic_16 = 16;
+
+/* Sink to prevent optimising away the call. */
+static volatile int sink;
+
+/*
+ * Each violation allocates a buffer of real size N, then calls a str
+ * function claiming size > N.  The runtime bounds check at the call
+ * site should trap.
+ */
+
+static void
+violate_str_append_len(void)
+{
+	str_t *STR_LOCAL s = str_new("");
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	memset(buf, 'A', real);
+	/* buf has 4 bytes, but we claim len=16 -> trap */
+	str_append_len(s, buf, dynamic_16);
+	sink = (int)str_length(s);
+	str_free(s, true);
+}
+
+static void
+violate_str_assign_len(void)
+{
+	str_t *STR_LOCAL s = str_new("hello");
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	memset(buf, 'B', real);
+	/* buf has 4 bytes, but we claim len=16 -> trap */
+	str_assign_len(s, buf, dynamic_16);
+	sink = (int)str_length(s);
+	str_free(s, true);
+}
+
+static void
+violate_str_insert_len(void)
+{
+	str_t *STR_LOCAL s = str_new("hello");
+	size_t real = dynamic_4;
+	char *buf = (char *)mem_alloc0(real);
+	memset(buf, 'C', real);
+	/* buf has 4 bytes, but we claim len=16 -> trap */
+	str_insert_len(s, 0, buf, dynamic_16);
+	sink = (int)str_length(s);
+	str_free(s, true);
+}
+
+static void
+violate_str_hexdump_new(void)
+{
+	size_t real = dynamic_4;
+	unsigned char *buf = (unsigned char *)mem_alloc0(real);
+	memset(buf, 0xAA, real);
+	/* buf has 4 bytes, but we claim len=16 -> trap */
+	str_t *STR_LOCAL s = str_hexdump_new(buf, dynamic_16);
+	sink = (int)str_length(s);
+	str_free(s, true);
+}
+
+static struct bounds_test_case cases[] = { { "str_append_len OOB buf", violate_str_append_len },
+					   { "str_assign_len OOB buf", violate_str_assign_len },
+					   { "str_insert_len OOB buf", violate_str_insert_len },
+					   { "str_hexdump_new OOB buf", violate_str_hexdump_new },
+					   { NULL, NULL } };
+
+#endif /* BOUNDS_SAFETY_ENABLED */
+
+BOUNDS_TEST_MAIN("str.bounds_test", cases)

--- a/common/str.c
+++ b/common/str.c
@@ -26,12 +26,13 @@
 #include <stdarg.h>
 #include <string.h>
 
+#include "bounds_safety.h"
 #include "str.h"
 #include "mem.h"
 #include "macro.h"
 
 struct str {
-	char *buf;
+	char *__sized_by(allocated_len) buf;
 	ssize_t len;
 	size_t allocated_len;
 };
@@ -44,17 +45,19 @@ str_expand(str_t *str, size_t len)
 	if (str->len + len < str->allocated_len)
 		return;
 
-	str->allocated_len = str->len + len + 1;
-	str->buf = mem_realloc(str->buf, str->allocated_len);
+	size_t new_alloc = str->len + len + 1;
+	str->buf = mem_realloc(str->buf, new_alloc);
+	str->allocated_len = new_alloc;
 }
 
 static void
 str_append_printf_internal(str_t *str, const char *fmt, va_list ap)
 {
-	char *buf;
+	char *__null_terminated buf;
 
 	buf = mem_vprintf(fmt, ap);
-	str_insert_len(str, -1, buf, -1);
+	size_t len = strlen(buf);
+	str_insert_len(str, -1, __unsafe_forge_bidi_indexable(const char *, buf, len), len);
 	mem_free0(buf);
 }
 
@@ -66,11 +69,13 @@ str_new(const char *init)
 	if (init == NULL || *init == '\0') {
 		str = str_new_len(2);
 	} else {
-		int len;
+		size_t len;
 
 		len = strlen(init);
 		str = str_new_len(len + 2);
-		str_append_len(str, init, len);
+		str_append_len(str,
+			       __unsafe_forge_bidi_indexable(const char *, init, len),
+			       len);
 	}
 	return str;
 }
@@ -114,11 +119,12 @@ str_assign(str_t *str, const char *buf)
 	IF_FALSE_RETURN(str->buf != buf);
 
 	str_truncate(str, 0);
-	str_insert_len(str, -1, buf, -1);
+	size_t len = strlen(buf);
+	str_insert_len(str, -1, __unsafe_forge_bidi_indexable(const char *, buf, len), len);
 }
 
 void
-str_assign_len(str_t *str, const char *buf, ssize_t len)
+str_assign_len(str_t *str, const char *__counted_by(len) buf, size_t len)
 {
 	IF_NULL_RETURN(str);
 	IF_NULL_RETURN(buf);
@@ -147,11 +153,12 @@ str_append(str_t *str, const char *buf)
 	IF_NULL_RETURN(str);
 	IF_NULL_RETURN(buf);
 
-	str_insert_len(str, -1, buf, -1);
+	size_t len = strlen(buf);
+	str_insert_len(str, -1, __unsafe_forge_bidi_indexable(const char *, buf, len), len);
 }
 
 void
-str_append_len(str_t *str, const char *buf, ssize_t len)
+str_append_len(str_t *str, const char *__counted_by(len) buf, size_t len)
 {
 	IF_NULL_RETURN(str);
 	IF_NULL_RETURN(buf);
@@ -175,17 +182,15 @@ str_insert(str_t *str, ssize_t pos, const char *buf)
 	IF_NULL_RETURN(str);
 	IF_NULL_RETURN(buf);
 
-	str_insert_len(str, pos, buf, -1);
+	size_t len = strlen(buf);
+	str_insert_len(str, pos, __unsafe_forge_bidi_indexable(const char *, buf, len), len);
 }
 
 void
-str_insert_len(str_t *str, ssize_t pos, const char *buf, ssize_t len)
+str_insert_len(str_t *str, ssize_t pos, const char *__counted_by(len) buf, size_t len)
 {
 	IF_NULL_RETURN(str);
 	IF_NULL_RETURN(buf);
-
-	if (len < 0)
-		len = strlen(buf);
 
 	if (pos < 0)
 		pos = str->len;
@@ -195,21 +200,22 @@ str_insert_len(str_t *str, ssize_t pos, const char *buf, ssize_t len)
 	str_expand(str, len);
 
 	if (buf >= str->buf && buf <= str->buf + str->len) {
-		ssize_t offset = buf - str->buf;
-		ssize_t precount = 0;
+		size_t offset = buf - str->buf;
+		size_t precount = 0;
 
-		buf = str->buf + offset;
+		const char *src = str->buf + offset;
 
 		if (pos < str->len)
 			memmove(str->buf + pos + len, str->buf + pos, str->len - pos);
 
-		if (offset < pos) {
-			precount = MIN(len, pos - offset);
-			memcpy(str->buf + pos, buf, precount);
+		if (offset < (size_t)pos) {
+			precount = MIN(len, (size_t)pos - offset);
+			memcpy(str->buf + pos, src, precount);
 		}
 
 		if (len > precount)
-			memcpy(str->buf + pos + precount, buf + precount + len, len - precount);
+			memcpy(str->buf + pos + precount, src + precount + len,
+			       len - precount);
 	} else {
 		if (pos < str->len)
 			memmove(str->buf + pos + len, str->buf + pos, str->len - pos);
@@ -234,7 +240,7 @@ const char *
 str_buffer(str_t *str)
 {
 	IF_NULL_RETVAL(str, NULL);
-	return str->buf;
+	return __unsafe_null_terminated_from_indexable(str->buf);
 }
 
 size_t
@@ -244,18 +250,20 @@ str_length(str_t *str)
 	return str->len;
 }
 
-char *
+char *__null_terminated
 str_free(str_t *str, bool free_buf)
 {
-	char *buf;
+	char *__null_terminated buf;
 
 	IF_NULL_RETVAL(str, NULL);
 
 	if (free_buf) {
-		mem_free0(str->buf);
+		free(str->buf);
+		str->buf = NULL;
+		str->allocated_len = 0;
 		buf = NULL;
 	} else {
-		buf = str->buf;
+		buf = __unsafe_null_terminated_from_indexable(str->buf);
 	}
 
 	mem_free0(str);
@@ -264,13 +272,12 @@ str_free(str_t *str, bool free_buf)
 }
 
 str_t *
-str_hexdump_new(unsigned char *mem, size_t len)
+str_hexdump_new(unsigned char *__counted_by(len) mem, size_t len)
 {
 	str_t *ret = str_new_len(len * 2 + 1);
 
-	while (len--) {
-		str_append_printf(ret, "%02x ", *mem);
-		mem++;
+	for (size_t i = 0; i < len; i++) {
+		str_append_printf(ret, "%02x ", mem[i]);
 	}
 
 	return ret;

--- a/common/str.c
+++ b/common/str.c
@@ -73,9 +73,7 @@ str_new(const char *init)
 
 		len = strlen(init);
 		str = str_new_len(len + 2);
-		str_append_len(str,
-			       __unsafe_forge_bidi_indexable(const char *, init, len),
-			       len);
+		str_append_len(str, __unsafe_forge_bidi_indexable(const char *, init, len), len);
 	}
 	return str;
 }
@@ -214,8 +212,7 @@ str_insert_len(str_t *str, ssize_t pos, const char *__counted_by(len) buf, size_
 		}
 
 		if (len > precount)
-			memcpy(str->buf + pos + precount, src + precount + len,
-			       len - precount);
+			memcpy(str->buf + pos + precount, src + precount + len, len - precount);
 	} else {
 		if (pos < str->len)
 			memmove(str->buf + pos + len, str->buf + pos, str->len - pos);
@@ -258,9 +255,7 @@ str_free(str_t *str, bool free_buf)
 	IF_NULL_RETVAL(str, NULL);
 
 	if (free_buf) {
-		free(str->buf);
-		str->buf = NULL;
-		str->allocated_len = 0;
+		mem_free0_sized(str->buf, str->allocated_len);
 		buf = NULL;
 	} else {
 		buf = __unsafe_null_terminated_from_indexable(str->buf);

--- a/common/str.h
+++ b/common/str.h
@@ -32,6 +32,8 @@
 #ifndef STR_H
 #define STR_H
 
+#include "bounds_safety.h"
+
 #include <unistd.h>
 #include <stdbool.h>
 
@@ -88,7 +90,7 @@ str_assign(str_t *str, const char *buf);
  * @param len The length of the string.
  */
 void
-str_assign_len(str_t *str, const char *buf, ssize_t len);
+str_assign_len(str_t *str, const char *__counted_by(len) buf, size_t len);
 
 /**
  * Assigns the content of the supplied format string to a string.
@@ -122,7 +124,7 @@ str_append(str_t *str, const char *buf);
  * @param len The length of the string.
  */
 void
-str_append_len(str_t *str, const char *buf, ssize_t len);
+str_append_len(str_t *str, const char *__counted_by(len) buf, size_t len);
 
 /**
  * Appends the content of the supplied format string to a string.
@@ -166,7 +168,7 @@ str_insert(str_t *str, ssize_t pos, const char *buf);
  * @param len The length of the string.
  */
 void
-str_insert_len(str_t *str, ssize_t pos, const char *buf, ssize_t len);
+str_insert_len(str_t *str, ssize_t pos, const char *__counted_by(len) buf, size_t len);
 
 /**
  * Shortens a string to the specified length.
@@ -205,7 +207,7 @@ str_length(str_t *str);
  * @return The resulting hex dump
  */
 str_t *
-str_hexdump_new(unsigned char *mem, size_t len);
+str_hexdump_new(unsigned char *__counted_by(len) mem, size_t len);
 
 /**
  * Frees the allocated string memory.
@@ -214,6 +216,6 @@ str_hexdump_new(unsigned char *mem, size_t len);
  * @param free_buf True: the internal string buffer should also be freed. False: the internal string buffer is not freed and a pointer to it is returned by the function.
  * @return If free_buf is false, a pointer to the internal string buffer is returned. Otherwise, NULL is returned.
  */
-char *
+char *__null_terminated
 str_free(str_t *str, bool free_buf);
 #endif /* STR_H */

--- a/common/uuid.c
+++ b/common/uuid.c
@@ -29,6 +29,7 @@
 #include <limits.h>
 #include <unistd.h>
 
+#include "bounds_safety.h"
 #include "macro.h"
 #include "mem.h"
 
@@ -48,8 +49,8 @@ struct uuid {
 	 * a uint64_t for easier usability. */
 	uint64_t node;
 
-	/* The string representation of the UUID */
-	char *string;
+	/* The string representation of the UUID (fixed 36 chars + NUL) */
+	char *__counted_by(37) string;
 };
 
 static int
@@ -82,7 +83,6 @@ static int
 uuid_fill_from_hex_string(uuid_t *uuid, const char *string)
 {
 	int ret = 0;
-	char *str;
 	int offset = 0;
 
 	TRACE("Trying to fill UUID from string: %s", string);
@@ -91,27 +91,31 @@ uuid_fill_from_hex_string(uuid_t *uuid, const char *string)
 		goto error;
 	}
 
-	str = mem_strndup(string + offset, 8);
+	/* string is __null_terminated; take one safe indexable view so the fixed-width
+	 * fields can be sliced out. The length check above guarantees >= 32 readable bytes. */
+	const char *buf = __null_terminated_to_indexable(string);
+
+	char *__null_terminated str = mem_strndup(buf + offset, 8);
 	ret += sscanf(str, "%" SCNx32, &uuid->time_low);
-	mem_free(str);
+	mem_free0(str);
 	offset += 8;
 
-	str = mem_strndup(string + offset, 4);
+	str = mem_strndup(buf + offset, 4);
 	ret += sscanf(str, "%" SCNx16, &uuid->time_mid);
-	mem_free(str);
+	mem_free0(str);
 	offset += 4;
 
-	str = mem_strndup(string + offset, 4);
+	str = mem_strndup(buf + offset, 4);
 	ret += sscanf(str, "%" SCNx16, &uuid->time_hi_and_version);
-	mem_free(str);
+	mem_free0(str);
 	offset += 4;
 
-	str = mem_strndup(string + offset, 4);
+	str = mem_strndup(buf + offset, 4);
 	ret += sscanf(str, "%" SCNx16, &uuid->clock_seq);
-	mem_free(str);
+	mem_free0(str);
 	offset += 4;
 
-	str = mem_strndup(string + offset, 12);
+	str = mem_strndup(buf + offset, 12);
 	ret += sscanf(str, "%" SCNx64, &uuid->node);
 	mem_free0(str);
 
@@ -153,7 +157,8 @@ uuid_new(char const *uuid)
 			0x8000; // Set reserved bits to 10 indicating UUID conforming to RFC 4122
 #else				/* LINUX */
 		// get a uuid string from /proc/kernel/random/uuid
-		FILE *f = fopen("/proc/sys/kernel/random/uuid", "r");
+		FILE *__single f =
+			__unsafe_forge_single(FILE *, fopen("/proc/sys/kernel/random/uuid", "r"));
 		if (!f) {
 			WARN_ERRNO("Could not open UUID providing file in sys filesystem");
 			goto error;
@@ -165,7 +170,9 @@ uuid_new(char const *uuid)
 			goto error;
 		}
 		fclose(f);
-		int ret = uuid_fill_from_string(u, buf);
+		/* buf is a fixed array; fgets above null-terminated it. Convert to the
+		 * __null_terminated param type (terminator verified within the array bounds). */
+		int ret = uuid_fill_from_string(u, __unsafe_null_terminated_from_indexable(buf));
 		if (ret < 0) {
 			goto error;
 		}
@@ -221,7 +228,10 @@ uuid_free(uuid_t *uuid)
 {
 	IF_NULL_RETURN(uuid);
 
-	mem_free0(uuid->string);
+	/* uuid->string is __counted_by(37): mem_free0() would null the pointer without
+	 * clearing the constant count, which -fbounds-safety rejects. Free without nulling
+	 * -- the containing struct is freed on the next line anyway. */
+	mem_free(uuid->string);
 	mem_free0(uuid);
 }
 
@@ -229,7 +239,7 @@ const char *
 uuid_string(const uuid_t *uuid)
 {
 	IF_NULL_RETVAL(uuid, NULL);
-	return uuid->string;
+	return __unsafe_null_terminated_from_indexable(uuid->string);
 }
 
 uint64_t

--- a/control/control.c
+++ b/control/control.c
@@ -983,7 +983,8 @@ handle_resp:
 		str_t *file_str = str_new(str_buffer(log_dir));
 		str_append(file_str, resp->log_message->name);
 
-		if (file_write_append(str_buffer(file_str), resp->log_message->msg, -1) < 0) {
+		if (file_write_append(str_buffer(file_str), resp->log_message->msg,
+				      strlen(resp->log_message->msg)) < 0) {
 			INFO("logfile %s could not be written.", resp->log_message->name);
 		}
 		protobuf_free_message((ProtobufCMessage *)resp);
@@ -1006,7 +1007,8 @@ handle_resp:
 		str_t *file_str = str_new(str_buffer(log_dir));
 		str_append(file_str, resp->log_message->name);
 
-		if (file_write_append(str_buffer(file_str), resp->log_message->msg, -1) < 0) {
+		if (file_write_append(str_buffer(file_str), resp->log_message->msg,
+				      strlen(resp->log_message->msg)) < 0) {
 			INFO("logfile %s could not be written.", resp->log_message->name);
 		}
 		protobuf_free_message((ProtobufCMessage *)resp);

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -67,6 +67,11 @@ ifeq ($(SANITIZERS),y)
     # to be installed on the build host
     LOCAL_CFLAGS += -lasan -fsanitize=address -fsanitize=undefined -fsanitize-recover=address
 endif
+BOUNDS_SAFETY ?= n
+ifeq ($(BOUNDS_SAFETY),y)
+    # requires bounds-safety-enabled Clang (swiftlang/llvm-project fork)
+    LOCAL_CFLAGS += -fbounds-safety
+endif
 ifeq ($(CC_MODE),y)
     LOCAL_CFLAGS += -DCC_MODE
 endif

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -507,7 +507,10 @@ audit_do_send_record(const container_t *c)
 	}
 	TRACE("read next audit record sucessfully");
 
-	packed_len = protobuf_pack_message_new((ProtobufCMessage *)message_proto, &packed);
+	protobuf_packed_msg_t packed_msg =
+		protobuf_pack_message_new((ProtobufCMessage *)message_proto);
+	packed = packed_msg.buf;
+	packed_len = packed_msg.len;
 
 	if (!packed) {
 		ERROR("Failed to pack protobuf message");

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -492,6 +492,7 @@ audit_next_record_new(const container_t *container, bool purge)
 static int
 audit_do_send_record(const container_t *c)
 {
+	protobuf_packed_msg_t packed_msg = { 0 };
 	uint8_t *packed = NULL;
 	uint32_t packed_len = 0;
 	int ret = -1;
@@ -507,8 +508,7 @@ audit_do_send_record(const container_t *c)
 	}
 	TRACE("read next audit record sucessfully");
 
-	protobuf_packed_msg_t packed_msg =
-		protobuf_pack_message_new((ProtobufCMessage *)message_proto);
+	packed_msg = protobuf_pack_message_new((ProtobufCMessage *)message_proto);
 	packed = packed_msg.buf;
 	packed_len = packed_msg.len;
 
@@ -539,7 +539,7 @@ out:
 
 	close(fd);
 
-	mem_free0(packed);
+	protobuf_pack_message_free(&packed_msg);
 	protobuf_free_message((ProtobufCMessage *)message_proto);
 	return ret;
 }

--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -344,7 +344,7 @@ c_cgroups_allow_rule(c_cgroups_t *cgroups, const char *rule)
 	// first allow in host-side list, which cannot manipulated by container (if namspaced)
 	char *path = mem_printf("%s/devices/%s/devices.allow", CGROUPS_FOLDER,
 				uuid_string(container_get_uuid(cgroups->container)));
-	if (file_write(path, rule, -1) == -1) {
+	if (file_write(path, rule, strlen(rule)) == -1) {
 		ERROR_ERRNO("Failed to write to %s", path);
 		mem_free0(path);
 		return -1;
@@ -354,7 +354,7 @@ c_cgroups_allow_rule(c_cgroups_t *cgroups, const char *rule)
 	char *path_child = mem_printf("%s/devices/%s/child/devices.allow", CGROUPS_FOLDER,
 				      uuid_string(container_get_uuid(cgroups->container)));
 	if (file_exists(path_child)) {
-		if (file_write(path, rule, -1) == -1) {
+		if (file_write(path, rule, strlen(rule)) == -1) {
 			ERROR_ERRNO("Failed to write to %s", path);
 			mem_free0(path);
 			mem_free0(path_child);
@@ -426,7 +426,7 @@ c_cgroups_devices_deny(void *cgroupsp, const char *rule)
 	char *path = mem_printf("%s/devices/%s/devices.deny", CGROUPS_FOLDER,
 				uuid_string(container_get_uuid(cgroups->container)));
 
-	if (file_write(path, rule, -1) == -1) {
+	if (file_write(path, rule, strlen(rule)) == -1) {
 		ERROR_ERRNO("Failed to write '%s' to %s", rule, path);
 		goto error;
 	}
@@ -572,7 +572,7 @@ c_cgroups_freeze(void *cgroupsp)
 
 	char *freezer_state_path = mem_printf("%s/freezer/%s/freezer.state", CGROUPS_FOLDER,
 					      uuid_string(container_get_uuid(cgroups->container)));
-	if (file_write(freezer_state_path, "FROZEN", -1) == -1) {
+	if (file_write(freezer_state_path, "FROZEN", strlen("FROZEN")) == -1) {
 		ERROR_ERRNO("Failed to write to freezer file %s", freezer_state_path);
 		mem_free0(freezer_state_path);
 		return -1;
@@ -591,7 +591,7 @@ c_cgroups_unfreeze(void *cgroupsp)
 
 	char *freezer_state_path = mem_printf("%s/freezer/%s/freezer.state", CGROUPS_FOLDER,
 					      uuid_string(container_get_uuid(cgroups->container)));
-	if (file_write(freezer_state_path, "THAWED", -1) == -1) {
+	if (file_write(freezer_state_path, "THAWED", strlen("THAWED")) == -1) {
 		ERROR_ERRNO("Failed to write to freezer file %s", freezer_state_path);
 		mem_free0(freezer_state_path);
 		return -1;

--- a/daemon/c_cgroups_v2.c
+++ b/daemon/c_cgroups_v2.c
@@ -415,7 +415,7 @@ c_cgroups_unfreeze(void *cgroupsp)
 	ASSERT(cgroups);
 
 	char *freezer_state_path = mem_printf("%s/cgroup.freeze", cgroups->path);
-	if (file_write(freezer_state_path, "0", -1) == -1) {
+	if (file_write(freezer_state_path, "0", strlen("0")) == -1) {
 		ERROR_ERRNO("Failed to write to freezer file %s", freezer_state_path);
 		mem_free0(freezer_state_path);
 		return -1;
@@ -478,7 +478,7 @@ c_cgroups_freeze(void *cgroupsp)
 	}
 
 	char *freezer_state_path = mem_printf("%s/cgroup.freeze", cgroups->path);
-	if (file_write(freezer_state_path, "1", -1) == -1) {
+	if (file_write(freezer_state_path, "1", strlen("1")) == -1) {
 		ERROR_ERRNO("Failed to write to freezer file %s", freezer_state_path);
 		mem_free0(freezer_state_path);
 		return -1;

--- a/daemon/c_oci.c
+++ b/daemon/c_oci.c
@@ -57,10 +57,14 @@ c_oci_start_pre_clone(void *ocip)
 	} else {
 		unsigned char key[TOKEN_KEY_LEN];
 		int keylen = crypto_random_get_bytes(key, sizeof(key));
-		ascii_key = convert_bin_to_hex_new(key, keylen);
+		if (keylen != sizeof(key)) {
+			ERROR("Failed to generate key for oci container, due to RNG Error!");
+		} else {
+			ascii_key = convert_bin_to_hex_new(key, keylen);
+			// include terminating null byte into file
+			file_write(oci->key_file, ascii_key, strlen(ascii_key) + 1);
+		}
 		mem_memset0(key, sizeof(key));
-		// include terminating null byte into file
-		file_write(oci->key_file, ascii_key, strlen(ascii_key) + 1);
 	}
 
 	if (ascii_key) {

--- a/daemon/compartment.c
+++ b/daemon/compartment.c
@@ -585,7 +585,7 @@ compartment_oom_protect_service(const compartment_t *compartment)
 	DEBUG("Setting oom_adj of trustme service (PID %d) in compartment %s to -17", service_pid,
 	      compartment_get_description(compartment));
 	char *path = mem_printf("/proc/%d/oom_adj", service_pid);
-	int ret = file_write(path, "-17", -1);
+	int ret = file_write(path, "-17", strlen("-17"));
 	if (ret < 0)
 		ERROR_ERRNO("Failed to write to %s", path);
 	mem_free0(path);
@@ -1003,8 +1003,9 @@ compartment_start_child(void *data)
 			ssize_t read_bytes;
 			char *kvm_log = mem_printf("%s.kvm.log", compartment->debug_log_dir);
 			read_bytes = read(fd_master, buffer, 128);
-			file_write(kvm_log, buffer, read_bytes);
-			while ((read_bytes = read(fd_master, buffer, 128))) {
+			if (read_bytes > 0)
+				file_write(kvm_log, buffer, read_bytes);
+			while ((read_bytes = read(fd_master, buffer, 128)) > 0) {
 				file_write_append(kvm_log, buffer, read_bytes);
 			}
 			return COMPARTMENT_ERROR;

--- a/daemon/control.test.c
+++ b/daemon/control.test.c
@@ -303,12 +303,12 @@ run_testsuite(int cmld_fd, void (*inject)(ControllerToDaemon *msg, void *data), 
 
 	// test Container_GET_CONTAINER_CONFIG 2
 	DEBUG("test Container_GET_CONTAINER_CONFIG 2");
-	file_write("test_A0.conf",
-		   "name: \"a0\"\nguest_os: \"a0os\"\nguestos_version: 20150408\ncolor: 1426918911",
-		   -1);
-	file_write("test_A1.conf",
-		   "name: \"a1\"\nguest_os: \"a1os\"\nguestos_version: 20150409\ncolor: 1426918912",
-		   -1);
+	const char *a0_conf =
+		"name: \"a0\"\nguest_os: \"a0os\"\nguestos_version: 20150408\ncolor: 1426918911";
+	const char *a1_conf =
+		"name: \"a1\"\nguest_os: \"a1os\"\nguestos_version: 20150409\ncolor: 1426918912";
+	file_write("test_A0.conf", a0_conf, strlen(a0_conf));
+	file_write("test_A1.conf", a1_conf, strlen(a1_conf));
 	msg_in.command = CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_CONFIG;
 	msg_in.n_container_uuids = 0;
 	test_handle_message(&msg_in, inject, data, cmld_fd, NULL);


### PR DESCRIPTION
Incrementally adopts Clang's `-fbounds-safety` for compile-time and runtime bounds checking across `common/`. The compatibility header `common/bounds_safety.h` defines every annotation as a no-op on GCC/stock Clang, so the default build is unaffected; full enforcement is available under the swiftlang Clang fork.

### Stacking

Stacked on **#603** (`bounds-safety-1-clang-build`). Until #603 merges, this PR's diff includes its commits; the work unique to this PR is:

- **eliminate sentinel values and modernize API signatures** — replace the `ssize_t len == -1 → strlen()` sentinel with `size_t len` + `__counted_by(len)` in `file_*`, `fd_write`, `str_*`; audited all callers repo-wide.
- **add -fbounds-safety annotations** — `hex`, `mem`, `fd`, `str`, `protobuf`, `file` (`__counted_by`/`__sized_by`/`__null_terminated`).
- **sock / protobuf-text / event / dir annotations** — `event` and `dir` are internal-only (annotations live in the `.c` files, so no `bounds_safety.h` header include and no `*.bounds_test.c` added).
- **`protobuf_pack_message_new` struct API** — returns a bounds-safe `protobuf_packed_msg_t` with a `protobuf_pack_message_free()` destructor instead of an out-param.
- **enforcement tests** — `*.bounds_test.c`, each verifying an out-of-bounds access traps under the bs-clang toolchain.
- **README** — document/parameterize the toolchain path.

### Verification

- Default GCC build of `libcommon` incl. `WITH_PROTOBUF_TEXT=y`, and the daemon (`cmld`) — clean under `-Werror`.
- `*.bounds_test` enforcement suite under the swiftlang Clang fork — all OOB accesses trap as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
