### PR TITLE
daemon/cmld: destroy container after failed creation

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1820,6 +1820,7 @@ cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint
 	mem_free0(path);
 	return c;
 err:
+	container_destroy(c);
 	container_free(c);
 	mem_free0(path);
 	return NULL;


### PR DESCRIPTION
The check if there is enough disk space available is done after the container is created. So if this check fails, the container did already create its submodules and wrote some files to disk. Therefore, we need to properly destroy the container instead of just a container_free to clean up the submodules and the config files already written to disk.